### PR TITLE
web/roomview: prevent room name overflowing the room invite view

### DIFF
--- a/web/src/ui/roomview/RoomPreview.css
+++ b/web/src/ui/roomview/RoomPreview.css
@@ -18,6 +18,8 @@ div.room-view.preview > div.preview-inner {
 
 	> h2.room-name {
 		margin: 0;
+		max-height: 6rem;
+		overflow-y: scroll;
 	}
 
 	> div.mutual-rooms {

--- a/web/src/ui/roomview/RoomPreview.css
+++ b/web/src/ui/roomview/RoomPreview.css
@@ -19,7 +19,7 @@ div.room-view.preview > div.preview-inner {
 	> h2.room-name {
 		margin: 0;
 		max-height: 6rem;
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 
 	> div.mutual-rooms {


### PR DESCRIPTION
Limits the height of the room name to 6rem and provides a y-scroll for names that exceed the height limit. Prevents invited rooms hiding the reject button