### PR TITLE
Def*ck Windows (make moving temporary files work)

### DIFF
--- a/pkg/gomuks/media.go
+++ b/pkg/gomuks/media.go
@@ -214,6 +214,7 @@ func (gmx *Gomuks) generateAvatarThumbnail(entry *database.Media, size int) erro
 	if err != nil {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
+	tempFile.Close()
 	err = os.Rename(tempFile.Name(), cachePath)
 	if err != nil {
 		return fmt.Errorf("failed to rename temporary file: %w", err)


### PR DESCRIPTION
Renaming (aka moving) a temporary file evidently does not seem to work on Windows when there is an open filehandle. This leads to all user and space avatars remaining blank as temporary files could not be moved to the cache. Simply closing the file before moving should make Windows behave (Linux had always just worked)