### PR TITLE
web: add preferences for the PWA title bar color

### DIFF
--- a/pkg/rpc/store/preferences.go
+++ b/pkg/rpc/store/preferences.go
@@ -40,6 +40,8 @@ type Preferences struct {
 	RoomWindowTitle         string `json:"room_window_title,omitempty"`
 	WindowTitle             string `json:"window_title,omitempty"`
 	Favicon                 string `json:"favicon,omitempty"`
+	ThemeColorLight         string `json:"theme_color_light,omitempty"`
+	ThemeColorDark          string `json:"theme_color_dark,omitempty"`
 	LowBandwidth            bool   `json:"low_bandwidth,omitempty"`
 	WebPush                 bool   `json:"web_push,omitempty"`
 }

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,8 @@
 	<meta charset="UTF-8"/>
 	<link id="favicon" rel="icon" type="image/png" href="gomuks.png"/>
 	<link rel="manifest" href="manifest.json"/>
+	<meta id="theme-color-light" name="theme-color" media="(prefers-color-scheme: light)" content="#f5f5f5"/>
+	<meta id="theme-color-dark" name="theme-color" media="(prefers-color-scheme: dark)" content="#222222"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, interactive-widget=resizes-content"/>
 	<title>gomuks web</title>
 	<!-- etag placeholder -->

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -27,6 +27,5 @@
 		"url": "#/uri/%s"
 	}],
 	"start_url": ".",
-	"display": "standalone",
-	"theme_color": "#00c853"
+	"display": "standalone"
 }

--- a/web/src/api/types/preferences/preferences.ts
+++ b/web/src/api/types/preferences/preferences.ts
@@ -296,6 +296,20 @@ export const preferences = {
 		defaultValue: "gomuks.png",
 		hidden: Boolean(window.gomuksAndroid || window.gomuksDesktop),
 	}),
+	theme_color_light: new Preference<string>({
+		displayName: "Light mode title bar color",
+		description: "The color of the window title bar when installed as a PWA, and of the browser toolbar on mobile, while the system is in light mode. Does not affect any colors inside the app.",
+		allowedContexts: anyGlobalContext,
+		defaultValue: "#f5f5f5",
+		hidden: Boolean(window.gomuksAndroid || window.gomuksDesktop),
+	}),
+	theme_color_dark: new Preference<string>({
+		displayName: "Dark mode title bar color",
+		description: "The color of the window title bar when installed as a PWA, and of the browser toolbar on mobile, while the system is in dark mode. Does not affect any colors inside the app.",
+		allowedContexts: anyGlobalContext,
+		defaultValue: "#222222",
+		hidden: Boolean(window.gomuksAndroid || window.gomuksDesktop),
+	}),
 	room_view_type: new Preference<RoomType | null>({
 		displayName: "Room type override",
 		description: "Use a specific view for this room instead of the default based on its type.",

--- a/web/src/ui/StylePreferences.tsx
+++ b/web/src/ui/StylePreferences.tsx
@@ -125,9 +125,17 @@ const StylePreferences = ({ client, activeRoom }: StylePreferencesProps) => {
 	useEffect(() => {
 		favicon.href = preferences.favicon
 	}, [preferences.favicon])
+	useEffect(() => {
+		themeColorLight.content = preferences.theme_color_light
+	}, [preferences.theme_color_light])
+	useEffect(() => {
+		themeColorDark.content = preferences.theme_color_dark
+	}, [preferences.theme_color_dark])
 	return null
 }
 
 const favicon = document.getElementById("favicon") as HTMLLinkElement
+const themeColorLight = document.getElementById("theme-color-light") as HTMLMetaElement
+const themeColorDark = document.getElementById("theme-color-dark") as HTMLMetaElement
 
 export default React.memo(StylePreferences)


### PR DESCRIPTION
Hi, thanks for Gomuks, it's really cool!

I discussed about this last night in the chat so here's a small PR. This PR includes a defaults change too.

Usually you want a dark gray or black color in a dark theme and a _white_ color in a light theme, so the defaults are now `#f5f5f5` for light and `#222222` for dark. Before this, the manifest `theme_color` hardcoded the green primary color, so installed PWAs got a green title bar no matter the system theme. It's replaced with theme-color meta tags gated on prefers-color-scheme, defaulting to the light and dark chrome colors of the app itself.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
