### PR TITLE
feat: user-configurable keybindings in web and terminal reply hotkey

### DIFF
--- a/tui/config/keybindings.yaml
+++ b/tui/config/keybindings.yaml
@@ -41,3 +41,4 @@ room:
     'PageUp': scroll_up
     'PageDown': scroll_down
     'Enter': send
+    'Ctrl+r': reply

--- a/tui/find-message.go
+++ b/tui/find-message.go
@@ -1,0 +1,81 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2025 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"maunium.net/go/mautrix/event"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/tui/messages"
+)
+
+type findFilter func(evt *database.Event) bool
+
+func isLocalEcho(evt *database.Event) bool {
+	if evt == nil || evt.ID == "" {
+		return true
+	}
+	return evt.TransactionID != "" && string(evt.ID) == evt.TransactionID
+}
+
+func asUIMessage(evt *database.Event) *messages.UIMessage {
+	if evt == nil || evt.RenderMeta == nil {
+		return nil
+	}
+	uiMsg, ok := evt.RenderMeta.(*messages.UIMessage)
+	if !ok || uiMsg == nil || uiMsg.IsService {
+		return nil
+	}
+	return uiMsg
+}
+
+func selectAllowed(evt *database.Event) bool {
+	if evt == nil || isLocalEcho(evt) {
+		return false
+	}
+	return evt.GetType() == event.EventMessage
+}
+
+func findMessageInTimeline(timeline []*database.Event, current *database.Event, forward bool, allow findFilter) *messages.UIMessage {
+	if len(timeline) == 0 {
+		return nil
+	}
+
+	currentFound := current == nil
+	for i := 0; i < len(timeline); i++ {
+		index := i
+		if !forward {
+			index = len(timeline) - i - 1
+		}
+		evt := timeline[index]
+		if isLocalEcho(evt) {
+			continue
+		}
+		uiMsg := asUIMessage(evt)
+		if uiMsg == nil {
+			continue
+		}
+		if currentFound {
+			if allow == nil || allow(evt) {
+				return uiMsg
+			}
+		} else if current != nil && evt.ID == current.ID {
+			currentFound = true
+		}
+	}
+	return nil
+}

--- a/tui/find-message_test.go
+++ b/tui/find-message_test.go
@@ -1,0 +1,114 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2025 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/tui/messages"
+)
+
+func makeTimelineEvent(eventID string, evtType string, txn string, service bool) *database.Event {
+	evt := &database.Event{
+		ID:            id.EventID(eventID),
+		Type:          evtType,
+		TransactionID: txn,
+	}
+	evt.RenderMeta = &messages.UIMessage{
+		Event:     evt,
+		IsService: service,
+	}
+	return evt
+}
+
+func TestFindMessageInTimeline_emptyAndNil(t *testing.T) {
+	if got := findMessageInTimeline(nil, nil, false, selectAllowed); got != nil {
+		t.Fatalf("nil timeline: got %v", got)
+	}
+	if got := findMessageInTimeline([]*database.Event{}, nil, false, selectAllowed); got != nil {
+		t.Fatalf("empty timeline: got %v", got)
+	}
+}
+
+func TestFindMessageInTimeline_skipsLocalEchoAndService(t *testing.T) {
+	echo := makeTimelineEvent("$echo", event.EventMessage.Type, "$echo", false)
+	notice := makeTimelineEvent("$svc", event.EventMessage.Type, "", true)
+	ok := makeTimelineEvent("$ok", event.EventMessage.Type, "", false)
+	member := makeTimelineEvent("$member", event.StateMember.Type, "", false)
+
+	got := findMessageInTimeline([]*database.Event{echo, notice, member, ok}, nil, false, selectAllowed)
+	if got == nil || got.ID != "$ok" {
+		t.Fatalf("expected $ok from end, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_previousFromNilSelectsLastAllowed(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+
+	got := findMessageInTimeline([]*database.Event{a, b, c}, nil, false, selectAllowed)
+	if got == nil || got.ID != "$c" {
+		t.Fatalf("expected last message $c, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_previousFromCurrent(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+	timeline := []*database.Event{a, b, c}
+
+	got := findMessageInTimeline(timeline, c, false, selectAllowed)
+	if got == nil || got.ID != "$b" {
+		t.Fatalf("expected $b before $c, got %#v", got)
+	}
+	got = findMessageInTimeline(timeline, a, false, selectAllowed)
+	if got != nil {
+		t.Fatalf("expected nil before first, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_nextFromCurrent(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+	timeline := []*database.Event{a, b, c}
+
+	got := findMessageInTimeline(timeline, a, true, selectAllowed)
+	if got == nil || got.ID != "$b" {
+		t.Fatalf("expected $b after $a, got %#v", got)
+	}
+	got = findMessageInTimeline(timeline, c, true, selectAllowed)
+	if got != nil {
+		t.Fatalf("expected nil after last, got %#v", got)
+	}
+}
+
+func TestSelectAllowed_rejectsNonMessage(t *testing.T) {
+	evt := makeTimelineEvent("$m", event.StateMember.Type, "", false)
+	if selectAllowed(evt) {
+		t.Fatal("state events must not be reply targets")
+	}
+	if selectAllowed(nil) {
+		t.Fatal("nil must not be allowed")
+	}
+}

--- a/tui/room-view.go
+++ b/tui/room-view.go
@@ -384,6 +384,9 @@ func (view *RoomView) OnKeyEvent(event mauview.KeyEvent) bool {
 	case "send":
 		view.InputSubmit(view.input.GetText())
 		return true
+	case "reply":
+		view.StartSelecting(SelectReply, "")
+		return true
 	}
 	return view.input.OnKeyEvent(event)
 }
@@ -456,42 +459,16 @@ func (view *RoomView) SetEditing(evt *database.Event) {
 	//view.input.SetCursorOffset(-1)
 }
 
-type findFilter func(evt *database.Event) bool
-
 func (view *RoomView) filterOwnOnly(evt *database.Event) bool {
 	return evt.Sender == view.parent.matrix.UserID && evt.GetType() == event.EventMessage
 }
 
-//func (view *RoomView) filterMediaOnly(evt *database.Event) bool {
-//	msgtype := event.MessageType(gjson.GetBytes(evt.GetContent(), "msgtype").Str)
-//	switch msgtype {
-//	case event.MsgFile, event.MsgImage, event.MsgAudio, event.MsgVideo:
-//		return true
-//	default:
-//		return false
-//	}
-//}
-
 func (view *RoomView) findMessage(current *database.Event, forward bool, allow findFilter) *messages.UIMessage {
-	//currentFound := current == nil
-	//msgs := view.MessageView().messages
-	//for i := 0; i < len(msgs); i++ {
-	//	index := i
-	//	if !forward {
-	//		index = len(msgs) - i - 1
-	//	}
-	//	evt := msgs[index]
-	//	if evt.EventID == "" || string(evt.EventID) == evt.TxnID || evt.IsService {
-	//		continue
-	//	} else if currentFound {
-	//		if allow == nil || allow(evt.Event) {
-	//			return evt
-	//		}
-	//	} else if evt.EventID == current.ID {
-	//		currentFound = true
-	//	}
-	//}
-	return nil
+	timelinePtr := view.Room.TimelineCache.Current()
+	if timelinePtr == nil {
+		return nil
+	}
+	return findMessageInTimeline(*timelinePtr, current, forward, allow)
 }
 
 func (view *RoomView) EditNext() {
@@ -499,7 +476,9 @@ func (view *RoomView) EditNext() {
 		return
 	}
 	foundMsg := view.findMessage(view.editing, true, view.filterOwnOnly)
-	view.SetEditing(foundMsg.GetEvent())
+	if foundMsg != nil {
+		view.SetEditing(foundMsg.GetEvent())
+	}
 }
 
 func (view *RoomView) EditPrevious() {
@@ -513,32 +492,24 @@ func (view *RoomView) EditPrevious() {
 }
 
 func (view *RoomView) SelectNext() {
-	//msgView := view.MessageView()
-	//if msgView.selected == 0 {
-	//	return
-	//}
-	//var filter findFilter
-	//if view.selectReason == SelectDownload || view.selectReason == SelectOpen {
-	//	filter = view.filterMediaOnly
-	//}
-	//foundMsg := view.findMessage(msgView.selected.GetEvent(), true, filter)
-	//if foundMsg != nil {
-	//	msgView.SetSelected(foundMsg)
-	//	// TODO scroll selected message into view
-	//}
+	msgView := view.MessageView()
+	if msgView.GetSelected() == nil {
+		return
+	}
+	foundMsg := view.findMessage(msgView.GetSelected().GetEvent(), true, selectAllowed)
+	if foundMsg != nil {
+		msgView.SetSelected(foundMsg)
+		// TODO scroll selected message into view
+	}
 }
 
 func (view *RoomView) SelectPrevious() {
-	//msgView := view.MessageView()
-	//var filter findFilter
-	//if view.selectReason == SelectDownload || view.selectReason == SelectOpen {
-	//	filter = view.filterMediaOnly
-	//}
-	//foundMsg := view.findMessage(msgView.selected.GetEvent(), false, filter)
-	//if foundMsg != nil {
-	//	msgView.SetSelected(foundMsg)
-	//	// TODO scroll selected message into view
-	//}
+	msgView := view.MessageView()
+	foundMsg := view.findMessage(msgView.GetSelected().GetEvent(), false, selectAllowed)
+	if foundMsg != nil {
+		msgView.SetSelected(foundMsg)
+		// TODO scroll selected message into view
+	}
 }
 
 type completion struct {

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -53,6 +53,7 @@ import EmojiPicker from "../emojipicker/EmojiPicker.tsx"
 import GIFPicker from "../emojipicker/GIFPicker.tsx"
 import StickerPicker from "../emojipicker/StickerPicker.tsx"
 import { keyToString } from "../keybindings.ts"
+import { buildEffectiveKeymap, loadKeybindOverrides } from "../keyconfig.ts"
 import { ModalContext, modals } from "../modal"
 import { useRoomContext } from "../roomview/roomcontext.ts"
 import { ReplyBody } from "../timeline/ReplyBody.tsx"
@@ -434,6 +435,7 @@ const MessageComposer = () => {
 	const onComposerKeyDown = (evt: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		const inp = evt.currentTarget
 		const fullKey = keyToString(evt)
+		const replyKeys = buildEffectiveKeymap(loadKeybindOverrides())
 		const sendKey = fullKey === "Enter" || fullKey === "Ctrl+Enter"
 			? (room.preferences.ctrl_enter_send ? "Ctrl+Enter" : "Enter")
 			: null
@@ -491,7 +493,7 @@ const MessageComposer = () => {
 		} else if (editing && fullKey === "Escape") {
 			evt.stopPropagation()
 			roomCtx.setEditing(null)
-		} else if (!editing && fullKey === "Ctrl+ArrowUp" && room.preferences.ctrl_arrow_reply) {
+		} else if (!editing && fullKey === replyKeys.reply_prev && room.preferences.ctrl_arrow_reply) {
 			let replyToIdx = replyToEvt ? room.timeline.findIndex(item => item.event_rowid === replyToEvt.rowid) : -1
 			if (replyToIdx === -1) {
 				replyToIdx = room.timeline.length - 1
@@ -506,7 +508,7 @@ const MessageComposer = () => {
 				evt.preventDefault()
 			}
 		} else if (!editing && replyToEvt !== null) {
-			if (fullKey === "Ctrl+ArrowDown" && room.preferences.ctrl_arrow_reply) {
+			if (fullKey === replyKeys.reply_next && room.preferences.ctrl_arrow_reply) {
 				const replyToIdx = room.timeline.findIndex(item => item.event_rowid === replyToEvt.rowid)
 				if (replyToIdx >= room.timeline.length - 1) {
 					roomCtx.setReplyTo(null)

--- a/web/src/ui/keybindings.test.ts
+++ b/web/src/ui/keybindings.test.ts
@@ -1,0 +1,396 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest"
+
+vi.mock("../api/statestore", () => ({
+	RoomStateStore: class RoomStateStore {},
+	StateStore: class StateStore {},
+}))
+
+vi.mock("./MainScreenContext.ts", () => ({}))
+
+import Keybindings, { keyToString } from "./keybindings.ts"
+
+type FakeEventInit = {
+	key?: string,
+	shiftKey?: boolean,
+	altKey?: boolean,
+	ctrlKey?: boolean,
+	metaKey?: boolean,
+	target?: unknown,
+	currentTarget?: unknown,
+}
+
+function fakeKeyEvent(init: FakeEventInit = {}) {
+	return {
+		key: init.key ?? "b",
+		shiftKey: init.shiftKey ?? false,
+		altKey: init.altKey ?? false,
+		ctrlKey: init.ctrlKey ?? false,
+		metaKey: init.metaKey ?? false,
+		target: init.target ?? document.body,
+		currentTarget: init.currentTarget ?? document.body,
+		preventDefault: vi.fn(),
+	} as unknown as KeyboardEvent
+}
+
+function makeRoom(roomID: string) {
+	return { room_id: roomID }
+}
+
+function makeContext(rightPanel: object | null = null) {
+	return {
+		setActiveRoom: vi.fn(),
+		clearActiveRoom: vi.fn(),
+		setRightPanel: vi.fn(),
+		closeRightPanel: vi.fn(),
+		rightPanelValue: rightPanel,
+		get currentRightPanel() {
+			return this.rightPanelValue
+		},
+		set currentRightPanel(value: object | null) {
+			this.rightPanelValue = value
+		},
+	}
+}
+
+function makeStore(rooms: Array<{ room_id: string }> = []) {
+	return {
+		getFilteredRoomList: vi.fn(() => rooms),
+	}
+}
+
+function setup(rooms: Array<{ room_id: string }> = [], rightPanel: object | null = null) {
+	const context = makeContext(rightPanel)
+	const kb = new Keybindings(makeStore(rooms) as any, context as any)
+	return { kb, context }
+}
+
+let composer: HTMLInputElement | undefined
+let search: HTMLInputElement | undefined
+
+beforeEach(() => {
+	localStorage.clear()
+	composer = document.createElement("input")
+	composer.id = "message-composer"
+	document.body.appendChild(composer)
+	vi.spyOn(composer, "focus")
+	search = document.createElement("input")
+	search.id = "room-search"
+	document.body.appendChild(search)
+	vi.spyOn(search, "focus")
+})
+
+afterEach(() => {
+	composer?.remove()
+	search?.remove()
+})
+
+describe("keyToString", () => {
+	test("plain key without modifiers", () => {
+		expect(keyToString(fakeKeyEvent({ key: "a" }))).toBe("a")
+	})
+
+	test("shift modifier", () => {
+		expect(keyToString(fakeKeyEvent({ key: "a", shiftKey: true }))).toBe("Shift+a")
+	})
+
+	test("alt modifier", () => {
+		expect(keyToString(fakeKeyEvent({ key: "Tab", altKey: true }))).toBe("Alt+Tab")
+	})
+
+	test("meta modifier", () => {
+		expect(keyToString(fakeKeyEvent({ key: "a", metaKey: true }))).toBe("Super+a")
+	})
+
+	test("ctrl modifier", () => {
+		expect(keyToString(fakeKeyEvent({ key: "k", ctrlKey: true }))).toBe("Ctrl+k")
+	})
+
+	test("ctrl+shift stack", () => {
+		expect(keyToString(fakeKeyEvent({ key: "a", ctrlKey: true, shiftKey: true })))
+			.toBe("Ctrl+Shift+a")
+	})
+
+	test("alt+shift stack", () => {
+		expect(keyToString(fakeKeyEvent({ key: "ArrowUp", altKey: true, shiftKey: true })))
+			.toBe("Alt+Shift+ArrowUp")
+	})
+
+	test("all four modifiers stacked", () => {
+		expect(keyToString(fakeKeyEvent({
+			key: "a", ctrlKey: true, metaKey: true, altKey: true, shiftKey: true,
+		}))).toBe("Ctrl+Super+Alt+Shift+a")
+	})
+
+	test("alt+ctrl stack prefixes ctrl last", () => {
+		expect(keyToString(fakeKeyEvent({ key: "f", altKey: true, ctrlKey: true })))
+			.toBe("Ctrl+Alt+f")
+	})
+})
+
+describe("Keybindings keyDownMap", () => {
+	test("Escape closes right panel when one is open", () => {
+		const { kb, context } = setup([], { type: "pinned-messages" })
+		kb.onKeyDown(fakeKeyEvent({ key: "Escape" }))
+		expect(context.closeRightPanel).toHaveBeenCalledTimes(1)
+		expect(context.clearActiveRoom).not.toHaveBeenCalled()
+	})
+
+	test("Escape clears active room when no right panel", () => {
+		const { kb, context } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "Escape" }))
+		expect(context.clearActiveRoom).toHaveBeenCalledTimes(1)
+		expect(context.closeRightPanel).not.toHaveBeenCalled()
+	})
+
+	test("Escape calls preventDefault", () => {
+		const { kb } = setup()
+		const evt = fakeKeyEvent({ key: "Escape" })
+		kb.onKeyDown(evt)
+		expect(evt.preventDefault).toHaveBeenCalledTimes(1)
+	})
+
+	test("Ctrl+k focuses room search", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "k", ctrlKey: true }))
+		expect(search!.focus).toHaveBeenCalledTimes(1)
+		expect(composer!.focus).not.toHaveBeenCalled()
+	})
+
+	test("Ctrl+k does nothing when room search is missing", () => {
+		search!.remove()
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "k", ctrlKey: true }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+	})
+
+	test("Alt+ArrowUp does nothing without an active room", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b")])
+		kb.activeRoom = null
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowUp", altKey: true }))
+		expect(context.setActiveRoom).not.toHaveBeenCalled()
+	})
+
+	test("Alt+ArrowUp selects the next room in the list", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b"), makeRoom("!c")])
+		kb.activeRoom = { roomID: "!a" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowUp", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith("!b")
+	})
+
+	test("Alt+ArrowUp wraps to null at the end of the list", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b")])
+		kb.activeRoom = { roomID: "!b" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowUp", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith(null)
+	})
+
+	test("Alt+ArrowUp with room not in list selects the first entry", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b")])
+		kb.activeRoom = { roomID: "!zzz" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowUp", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith("!a")
+	})
+
+	test("Alt+ArrowDown selects the last room when nothing is active", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b"), makeRoom("!c")])
+		kb.activeRoom = null
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowDown", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith("!c")
+	})
+
+	test("Alt+ArrowDown selects the previous room in the list", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b"), makeRoom("!c")])
+		kb.activeRoom = { roomID: "!b" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowDown", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith("!a")
+	})
+
+	test("Alt+ArrowDown does nothing at the top of the list", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b")])
+		kb.activeRoom = { roomID: "!a" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowDown", altKey: true }))
+		expect(context.setActiveRoom).not.toHaveBeenCalled()
+	})
+
+	test("Alt+ArrowDown with active room not in list selects the last entry", () => {
+		const { kb, context } = setup([makeRoom("!a"), makeRoom("!b")])
+		kb.activeRoom = { roomID: "!zzz" } as any
+		kb.onKeyDown(fakeKeyEvent({ key: "ArrowDown", altKey: true }))
+		expect(context.setActiveRoom).toHaveBeenCalledWith("!b")
+	})
+
+	test("Ctrl+f opens the search right panel", () => {
+		const { kb, context } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "f", ctrlKey: true }))
+		expect(context.setRightPanel).toHaveBeenCalledWith({ type: "search" })
+	})
+})
+
+describe("Keybindings auto-focus composer fallback", () => {
+	test("unbound plain key focuses the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "b" }))
+		expect(composer!.focus).toHaveBeenCalledTimes(1)
+	})
+
+	test("unbound key with ctrl held does not focus the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "b", ctrlKey: true }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+	})
+
+	test("unbound key with meta held does not focus the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "b", metaKey: true }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+	})
+
+	test("ctrl+v still focuses the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "v", ctrlKey: true }))
+		expect(composer!.focus).toHaveBeenCalledTimes(1)
+	})
+
+	test("ctrl+a still focuses the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "a", ctrlKey: true }))
+		expect(composer!.focus).toHaveBeenCalledTimes(1)
+	})
+
+	test("alt-held key does not focus the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "b", altKey: true }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+	})
+
+	test("shift-held key still focuses the composer", () => {
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "B", shiftKey: true }))
+		expect(composer!.focus).toHaveBeenCalledTimes(1)
+	})
+
+	for (const navKey of ["PageUp", "PageDown", "Home", "End"]) {
+		test(`${navKey} does not focus the composer`, () => {
+			const { kb } = setup()
+			kb.onKeyDown(fakeKeyEvent({ key: navKey }))
+			expect(composer!.focus).not.toHaveBeenCalled()
+		})
+	}
+
+	test("event targeting a child element does not focus the composer", () => {
+		const { kb } = setup()
+		const child = document.createElement("div")
+		document.body.appendChild(child)
+		kb.onKeyDown(fakeKeyEvent({ key: "b", target: child, currentTarget: document.body }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+		child.remove()
+	})
+
+	test("key handled by keyUpMap does not focus the composer", () => {
+		const { kb } = setup()
+		const handler = vi.fn()
+		;(kb as any).keyUpMap["F9"] = handler
+		kb.onKeyDown(fakeKeyEvent({ key: "F9" }))
+		expect(composer!.focus).not.toHaveBeenCalled()
+		delete (kb as any).keyUpMap["F9"]
+	})
+
+	test("fallback does not call preventDefault", () => {
+		const { kb } = setup()
+		const evt = fakeKeyEvent({ key: "b" })
+		kb.onKeyDown(evt)
+		expect(evt.preventDefault).not.toHaveBeenCalled()
+	})
+
+	test("composer focus is a no-op when the composer is missing", () => {
+		composer!.remove()
+		const { kb } = setup()
+		kb.onKeyDown(fakeKeyEvent({ key: "b" }))
+		expect(true).toBe(true)
+	})
+})
+
+describe("Keybindings keyUpMap", () => {
+	test("keyup with no registered handler is a no-op", () => {
+		const { kb } = setup()
+		expect(() => kb.onKeyUp(fakeKeyEvent({ key: "b" }))).not.toThrow()
+	})
+
+	test("keyup dispatches to a registered keyUpMap handler", () => {
+		const { kb } = setup()
+		const handler = vi.fn()
+		;(kb as any).keyUpMap["Alt+x"] = handler
+		const evt = fakeKeyEvent({ key: "x", altKey: true })
+		kb.onKeyUp(evt)
+		expect(handler).toHaveBeenCalledTimes(1)
+		expect(handler).toHaveBeenCalledWith(evt)
+	})
+})
+
+describe("Keybindings listen", () => {
+	test("listen attaches keydown and keyup handlers and dispose detaches them", () => {
+		const addSpy = vi.spyOn(document.body, "addEventListener")
+		const removeSpy = vi.spyOn(document.body, "removeEventListener")
+		const winAdd = vi.spyOn(window, "addEventListener")
+		const winRemove = vi.spyOn(window, "removeEventListener")
+		const { kb } = setup()
+		const dispose = kb.listen()
+		expect(addSpy).toHaveBeenCalledWith("keydown", kb.onKeyDown)
+		expect(addSpy).toHaveBeenCalledWith("keyup", kb.onKeyUp)
+		expect(winAdd).toHaveBeenCalledWith("gomuks-keybindings-changed", kb.reload)
+		dispose()
+		expect(removeSpy).toHaveBeenCalledWith("keydown", kb.onKeyDown)
+		expect(removeSpy).toHaveBeenCalledWith("keyup", kb.onKeyUp)
+		expect(winRemove).toHaveBeenCalledWith("gomuks-keybindings-changed", kb.reload)
+		addSpy.mockRestore()
+		removeSpy.mockRestore()
+		winAdd.mockRestore()
+		winRemove.mockRestore()
+	})
+
+	test("attached listeners dispatch real keydown events", () => {
+		const { kb, context } = setup()
+		const dispose = kb.listen()
+		document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+		expect(context.clearActiveRoom).toHaveBeenCalledTimes(1)
+		document.body.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }))
+		dispose()
+		document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+		expect(context.clearActiveRoom).toHaveBeenCalledTimes(1)
+	})
+
+	test("listen twice returns independent disposers", () => {
+		const { kb } = setup()
+		const dispose1 = kb.listen()
+		const dispose2 = kb.listen()
+		expect(() => {
+			dispose1()
+			dispose2()
+		}).not.toThrow()
+	})
+
+	test("reload picks up localStorage overrides", () => {
+		const { kb, context } = setup()
+		localStorage.setItem("gomuks-keybindings", JSON.stringify({ close_panel: "F10" }))
+		kb.reload()
+		kb.onKeyDown(fakeKeyEvent({ key: "Escape" }))
+		expect(context.clearActiveRoom).not.toHaveBeenCalled()
+		kb.onKeyDown(fakeKeyEvent({ key: "F10" }))
+		expect(context.clearActiveRoom).toHaveBeenCalledTimes(1)
+	})
+})

--- a/web/src/ui/keybindings.ts
+++ b/web/src/ui/keybindings.ts
@@ -16,6 +16,7 @@
 import React from "react"
 import { RoomStateStore, StateStore } from "@/api/statestore"
 import { MainScreenContextFields } from "@/ui/MainScreenContext.ts"
+import { KEYBINDINGS_CHANGED_EVENT, buildEffectiveKeymap, loadKeybindOverrides } from "./keyconfig.ts"
 
 export function keyToString(evt: React.KeyboardEvent | KeyboardEvent) {
 	let key = evt.key
@@ -38,53 +39,67 @@ type KeyMap = Record<string, (evt: KeyboardEvent) => void>
 
 export default class Keybindings {
 	public activeRoom: RoomStateStore | null = null
-	constructor(private store: StateStore, private context: MainScreenContextFields) {}
+	private keyDownMap: KeyMap = {}
+	private keyUpMap: KeyMap = {}
 
-	private keyDownMap: KeyMap = {
-		"Escape": () => {
-			if (this.context.currentRightPanel) {
-				this.context.closeRightPanel()
-			} else {
-				this.context.clearActiveRoom()
-			}
-		},
-		"Ctrl+k": () => document.getElementById("room-search")?.focus(),
-		"Alt+ArrowUp": () => {
-			if (!this.activeRoom) {
-				return
-			}
-			const activeRoomID = this.activeRoom.roomID
-			const filteredRoomList = this.store.getFilteredRoomList()
-			const selectedIdx = filteredRoomList.findLastIndex(room => room.room_id === activeRoomID)
-			if (selectedIdx < filteredRoomList.length - 1) {
-				this.context.setActiveRoom(filteredRoomList[selectedIdx + 1].room_id)
-			} else {
-				this.context.setActiveRoom(null)
-			}
-		},
-		"Alt+ArrowDown": () => {
-			const filteredRoomList = this.store.getFilteredRoomList()
-			const selectedIdx = this.activeRoom
-				? filteredRoomList.findLastIndex(room => room.room_id === this.activeRoom?.roomID)
-				: -1
-			if (selectedIdx === -1) {
-				this.context.setActiveRoom(filteredRoomList[filteredRoomList.length - 1].room_id)
-			} else if (selectedIdx > 0) {
-				this.context.setActiveRoom(filteredRoomList[selectedIdx - 1].room_id)
-			}
-		},
-		"Ctrl+f": () => this.context.setRightPanel({ type: "search" }),
+	constructor(private store: StateStore, private context: MainScreenContextFields) {
+		this.buildKeymaps()
 	}
 
-	private keyUpMap: KeyMap = {
+	private buildKeymaps(): void {
+		const overrides = loadKeybindOverrides()
+		const effective = buildEffectiveKeymap(overrides)
+
+		this.keyDownMap = {
+			[effective.close_panel]: () => {
+				if (this.context.currentRightPanel) {
+					this.context.closeRightPanel()
+				} else {
+					this.context.clearActiveRoom()
+				}
+			},
+			[effective.focus_room_search]: () => document.getElementById("room-search")?.focus(),
+			[effective.next_room]: () => {
+				if (!this.activeRoom) {
+					return
+				}
+				const activeRoomID = this.activeRoom.roomID
+				const filteredRoomList = this.store.getFilteredRoomList()
+				const selectedIdx = filteredRoomList.findLastIndex(room => room.room_id === activeRoomID)
+				if (selectedIdx < filteredRoomList.length - 1) {
+					this.context.setActiveRoom(filteredRoomList[selectedIdx + 1].room_id)
+				} else {
+					this.context.setActiveRoom(null)
+				}
+			},
+			[effective.prev_room]: () => {
+				const filteredRoomList = this.store.getFilteredRoomList()
+				const selectedIdx = this.activeRoom
+					? filteredRoomList.findLastIndex(room => room.room_id === this.activeRoom?.roomID)
+					: -1
+				if (selectedIdx === -1) {
+					this.context.setActiveRoom(filteredRoomList[filteredRoomList.length - 1].room_id)
+				} else if (selectedIdx > 0) {
+					this.context.setActiveRoom(filteredRoomList[selectedIdx - 1].room_id)
+				}
+			},
+			[effective.open_search]: () => this.context.setRightPanel({ type: "search" }),
+		}
+	}
+
+	/** Reload keybindings from localStorage (call after user changes config) */
+	public reload = (): void => {
+		this.buildKeymaps()
 	}
 
 	listen(): () => void {
 		document.body.addEventListener("keydown", this.onKeyDown)
 		document.body.addEventListener("keyup", this.onKeyUp)
+		window.addEventListener(KEYBINDINGS_CHANGED_EVENT, this.reload)
 		return () => {
 			document.body.removeEventListener("keydown", this.onKeyDown)
 			document.body.removeEventListener("keyup", this.onKeyUp)
+			window.removeEventListener(KEYBINDINGS_CHANGED_EVENT, this.reload)
 		}
 	}
 

--- a/web/src/ui/keyconfig.test.ts
+++ b/web/src/ui/keyconfig.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, test } from "vitest"
+
+import {
+	DEFAULT_KEYBINDINGS,
+	KEYBINDINGS_CHANGED_EVENT,
+	buildEffectiveKeymap,
+	clearKeybindOverrides,
+	loadKeybindOverrides,
+	resolveKey,
+	saveKeybindOverrides,
+	validateKeybindings,
+} from "./keyconfig.ts"
+
+describe("DEFAULT_KEYBINDINGS", () => {
+	test("has all expected actions", () => {
+		expect(Object.keys(DEFAULT_KEYBINDINGS)).toEqual([
+			"close_panel",
+			"clear_room",
+			"focus_room_search",
+			"next_room",
+			"prev_room",
+			"open_search",
+			"reply_prev",
+			"reply_next",
+		])
+	})
+
+	test("matches original hardcoded values", () => {
+		expect(DEFAULT_KEYBINDINGS.close_panel).toBe("Escape")
+		expect(DEFAULT_KEYBINDINGS.focus_room_search).toBe("Ctrl+k")
+		expect(DEFAULT_KEYBINDINGS.next_room).toBe("Alt+ArrowUp")
+		expect(DEFAULT_KEYBINDINGS.prev_room).toBe("Alt+ArrowDown")
+		expect(DEFAULT_KEYBINDINGS.open_search).toBe("Ctrl+f")
+		expect(DEFAULT_KEYBINDINGS.reply_prev).toBe("Ctrl+ArrowUp")
+		expect(DEFAULT_KEYBINDINGS.reply_next).toBe("Ctrl+ArrowDown")
+	})
+})
+
+describe("validateKeybindings", () => {
+	test("empty overrides are valid", () => {
+		expect(validateKeybindings({})).toEqual({ valid: true, errors: [] })
+	})
+
+	test("valid override passes", () => {
+		const result = validateKeybindings({ close_panel: "Ctrl+q" })
+		expect(result.valid).toBe(true)
+		expect(result.errors).toEqual([])
+	})
+
+	test("unknown action is rejected", () => {
+		const result = validateKeybindings({ nonexistent_action: "Ctrl+q" })
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContain('Unknown action "nonexistent_action"')
+	})
+
+	test("empty key is rejected", () => {
+		const result = validateKeybindings({ close_panel: "" })
+		expect(result.valid).toBe(false)
+		expect(result.errors.some(e => e.includes("empty"))).toBe(true)
+	})
+
+	test("whitespace-only key is rejected", () => {
+		const result = validateKeybindings({ close_panel: "   " })
+		expect(result.valid).toBe(false)
+	})
+
+	test("reserved Enter key is rejected", () => {
+		const result = validateKeybindings({ close_panel: "Enter" })
+		expect(result.valid).toBe(false)
+		expect(result.errors.some(e => e.includes("reserved"))).toBe(true)
+	})
+
+	test("reserved Tab key is rejected", () => {
+		const result = validateKeybindings({ close_panel: "Tab" })
+		expect(result.valid).toBe(false)
+		expect(result.errors.some(e => e.includes("reserved"))).toBe(true)
+	})
+
+	test("duplicate keys across actions are rejected", () => {
+		const result = validateKeybindings({
+			close_panel: "Ctrl+q",
+			open_search: "Ctrl+q",
+		})
+		expect(result.valid).toBe(false)
+		expect(result.errors.some(e => e.includes("Duplicate"))).toBe(true)
+	})
+
+	test("override colliding with another action default is rejected", () => {
+		const result = validateKeybindings({ next_room: "Alt+ArrowDown" })
+		expect(result.valid).toBe(false)
+		expect(result.errors.some(e => e.includes("Duplicate"))).toBe(true)
+	})
+
+	test("non-string value is rejected", () => {
+		const result = validateKeybindings({ close_panel: 42 as unknown as string })
+		expect(result.valid).toBe(false)
+	})
+
+	test("null value is rejected", () => {
+		const result = validateKeybindings({ close_panel: null as unknown as string })
+		expect(result.valid).toBe(false)
+	})
+})
+
+describe("localStorage round-trip", () => {
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	test("loadKeybindOverrides returns empty when nothing stored", () => {
+		expect(loadKeybindOverrides()).toEqual({})
+	})
+
+	test("saveKeybindOverrides + loadKeybindOverrides round-trips", () => {
+		saveKeybindOverrides({ close_panel: "Ctrl+q" })
+		expect(loadKeybindOverrides()).toEqual({ close_panel: "Ctrl+q" })
+	})
+
+	test("saveKeybindOverrides notifies listeners", () => {
+		let fired = 0
+		const onChange = () => { fired += 1 }
+		window.addEventListener(KEYBINDINGS_CHANGED_EVENT, onChange)
+		saveKeybindOverrides({ close_panel: "Ctrl+q" })
+		window.removeEventListener(KEYBINDINGS_CHANGED_EVENT, onChange)
+		expect(fired).toBe(1)
+	})
+
+	test("saveKeybindOverrides throws on invalid overrides", () => {
+		expect(() => saveKeybindOverrides({ bogus: "Ctrl+q" })).toThrow()
+	})
+
+	test("saveKeybindOverrides does NOT write when invalid", () => {
+		try {
+			saveKeybindOverrides({ bogus: "Ctrl+q" })
+		} catch {
+			// expected
+		}
+		expect(localStorage.getItem("gomuks-keybindings")).toBeNull()
+	})
+
+	test("clearKeybindOverrides removes stored data", () => {
+		saveKeybindOverrides({ close_panel: "Ctrl+q" })
+		clearKeybindOverrides()
+		expect(loadKeybindOverrides()).toEqual({})
+	})
+
+	test("loadKeybindOverrides handles corrupt JSON gracefully", () => {
+		localStorage.setItem("gomuks-keybindings", "not-json{{{")
+		expect(loadKeybindOverrides()).toEqual({})
+	})
+
+	test("loadKeybindOverrides handles non-object JSON gracefully", () => {
+		localStorage.setItem("gomuks-keybindings", JSON.stringify([1, 2, 3]))
+		expect(loadKeybindOverrides()).toEqual({})
+	})
+
+	test("loadKeybindOverrides handles null JSON gracefully", () => {
+		localStorage.setItem("gomuks-keybindings", "null")
+		expect(loadKeybindOverrides()).toEqual({})
+	})
+})
+
+describe("resolveKey", () => {
+	test("returns default when no override", () => {
+		expect(resolveKey("close_panel", {})).toBe("Escape")
+	})
+
+	test("returns override when present", () => {
+		expect(resolveKey("close_panel", { close_panel: "Ctrl+q" })).toBe("Ctrl+q")
+	})
+
+	test("returns default when override is empty", () => {
+		expect(resolveKey("close_panel", { close_panel: "" })).toBe("Escape")
+	})
+
+	test("returns default when override is whitespace", () => {
+		expect(resolveKey("close_panel", { close_panel: "  " })).toBe("Escape")
+	})
+})
+
+describe("buildEffectiveKeymap", () => {
+	test("returns defaults when no overrides", () => {
+		expect(buildEffectiveKeymap({})).toEqual(DEFAULT_KEYBINDINGS)
+	})
+
+	test("overrides replace defaults", () => {
+		const result = buildEffectiveKeymap({ close_panel: "Ctrl+q" })
+		expect(result.close_panel).toBe("Ctrl+q")
+		expect(result.focus_room_search).toBe("Ctrl+k")
+	})
+
+	test("ignores unknown actions", () => {
+		const result = buildEffectiveKeymap({ unknown_action: "Ctrl+q" })
+		expect(result).toEqual(DEFAULT_KEYBINDINGS)
+	})
+
+	test("does not mutate defaults", () => {
+		const overrides = { close_panel: "Ctrl+q" }
+		buildEffectiveKeymap(overrides)
+		expect(DEFAULT_KEYBINDINGS.close_panel).toBe("Escape")
+	})
+})

--- a/web/src/ui/keyconfig.ts
+++ b/web/src/ui/keyconfig.ts
@@ -1,0 +1,194 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Configurable keybinding system for the web client.
+ *
+ * Storage: localStorage key "gomuks-keybindings" holds a JSON object
+ * mapping action names to key strings (e.g. {"close_panel": "Escape"}).
+ *
+ * Defaults match the original hardcoded map in keybindings.ts plus the
+ * composer reply-select keys.
+ *
+ * Validation rules:
+ * - Key must be non-empty string
+ * - Action must be a known action name
+ * - No duplicate keys across independently bindable actions
+ * - Reserved keys (Enter, Tab) cannot be bound
+ */
+
+export type ActionName =
+	| "close_panel"
+	| "clear_room"
+	| "focus_room_search"
+	| "next_room"
+	| "prev_room"
+	| "open_search"
+	| "reply_prev"
+	| "reply_next"
+
+/** Actions shown in the settings panel (independently bindable). */
+export const BINDABLE_ACTIONS: ActionName[] = [
+	"close_panel",
+	"focus_room_search",
+	"next_room",
+	"prev_room",
+	"open_search",
+	"reply_prev",
+	"reply_next",
+]
+
+export const ACTION_LABELS: Record<ActionName, string> = {
+	close_panel: "Close right panel / leave room",
+	clear_room: "Leave room (same key as close panel)",
+	focus_room_search: "Focus room search",
+	next_room: "Next room",
+	prev_room: "Previous room",
+	open_search: "Open search panel",
+	reply_prev: "Reply to previous message",
+	reply_next: "Reply to next message",
+}
+
+/** Default keybindings matching the original hardcoded map */
+export const DEFAULT_KEYBINDINGS: Record<ActionName, string> = {
+	close_panel: "Escape",
+	clear_room: "Escape",
+	focus_room_search: "Ctrl+k",
+	next_room: "Alt+ArrowUp",
+	prev_room: "Alt+ArrowDown",
+	open_search: "Ctrl+f",
+	reply_prev: "Ctrl+ArrowUp",
+	reply_next: "Ctrl+ArrowDown",
+}
+
+export const STORAGE_KEY = "gomuks-keybindings"
+export const KEYBINDINGS_CHANGED_EVENT = "gomuks-keybindings-changed"
+
+/** Keys that are always reserved for composer input */
+const RESERVED_KEYS = new Set(["Enter", "Tab"])
+
+export interface KeybindValidationResult {
+	valid: boolean
+	errors: string[]
+}
+
+function notifyKeybindingsChanged(): void {
+	if (typeof window === "undefined") {
+		return
+	}
+	window.dispatchEvent(new Event(KEYBINDINGS_CHANGED_EVENT))
+}
+
+/**
+ * Validate a keybinding override map.
+ * Returns errors for: empty keys, unknown actions, duplicate keys, reserved keys.
+ * Duplicate detection uses the merged (defaults + overrides) bindable map so
+ * an override cannot silently collide with another action's default.
+ */
+export function validateKeybindings(overrides: Record<string, string>): KeybindValidationResult {
+	const errors: string[] = []
+	const knownActions = new Set<string>(Object.keys(DEFAULT_KEYBINDINGS))
+
+	for (const [action, key] of Object.entries(overrides)) {
+		if (typeof key !== "string" || key.trim() === "") {
+			errors.push(`Action "${action}" has empty or non-string key`)
+			continue
+		}
+		if (!knownActions.has(action)) {
+			errors.push(`Unknown action "${action}"`)
+			continue
+		}
+		if (RESERVED_KEYS.has(key)) {
+			errors.push(`Key "${key}" is reserved and cannot be bound`)
+		}
+	}
+
+	const merged = buildEffectiveKeymap(overrides)
+	const seenKeys = new Map<string, string>()
+	for (const action of BINDABLE_ACTIONS) {
+		const key = merged[action]
+		const existingAction = seenKeys.get(key)
+		if (existingAction) {
+			errors.push(`Duplicate key "${key}" bound to both "${existingAction}" and "${action}"`)
+		} else {
+			seenKeys.set(key, action)
+		}
+	}
+
+	return { valid: errors.length === 0, errors }
+}
+
+/**
+ * Load user keybinding overrides from localStorage.
+ * Returns empty object if nothing stored or parse fails.
+ */
+export function loadKeybindOverrides(): Record<string, string> {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY)
+		if (!raw) return {}
+		const parsed = JSON.parse(raw)
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {}
+		return parsed as Record<string, string>
+	} catch {
+		return {}
+	}
+}
+
+/**
+ * Save keybinding overrides to localStorage.
+ * Validates before saving; throws if invalid.
+ */
+export function saveKeybindOverrides(overrides: Record<string, string>): void {
+	const result = validateKeybindings(overrides)
+	if (!result.valid) {
+		throw new Error(`Invalid keybindings: ${result.errors.join("; ")}`)
+	}
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides))
+	notifyKeybindingsChanged()
+}
+
+/**
+ * Clear all user overrides, reverting to defaults.
+ */
+export function clearKeybindOverrides(): void {
+	localStorage.removeItem(STORAGE_KEY)
+	notifyKeybindingsChanged()
+}
+
+/**
+ * Resolve the effective keybinding for an action.
+ * User override wins if present and valid; otherwise default.
+ */
+export function resolveKey(action: ActionName, overrides: Record<string, string>): string {
+	const userKey = overrides[action]
+	if (typeof userKey === "string" && userKey.trim() !== "") {
+		return userKey
+	}
+	return DEFAULT_KEYBINDINGS[action]
+}
+
+/**
+ * Build the full effective keymap: action → key, with overrides merged in.
+ */
+export function buildEffectiveKeymap(overrides: Record<string, string>): Record<ActionName, string> {
+	const result = { ...DEFAULT_KEYBINDINGS }
+	for (const [action, key] of Object.entries(overrides)) {
+		if (action in result && typeof key === "string" && key.trim() !== "") {
+			(result as Record<string, string>)[action] = key
+		}
+	}
+	return result
+}

--- a/web/src/ui/settings/KeybindingsSettings.test.tsx
+++ b/web/src/ui/settings/KeybindingsSettings.test.tsx
@@ -1,0 +1,96 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { act } from "react"
+import { createElement } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import KeybindingsSettings from "./KeybindingsSettings.tsx"
+
+beforeEach(() => {
+	(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+	localStorage.clear()
+})
+
+describe("KeybindingsSettings", () => {
+	let container: HTMLDivElement
+	let root: Root
+
+	beforeEach(() => {
+		container = document.createElement("div")
+		document.body.appendChild(container)
+		root = createRoot(container)
+	})
+
+	afterEach(() => {
+		act(() => root.unmount())
+		container.remove()
+	})
+
+	test("renders default shortcuts", () => {
+		act(() => root.render(createElement(KeybindingsSettings)))
+		expect(container.textContent).toContain("Focus room search")
+		expect(container.textContent).toContain("Ctrl+k")
+		expect(container.textContent).toContain("Reply to previous message")
+		expect(container.textContent).toContain("Ctrl+ArrowUp")
+	})
+
+	test("records a new shortcut and persists it", () => {
+		act(() => root.render(createElement(KeybindingsSettings)))
+		const buttons = [...container.querySelectorAll("button")]
+		const searchBtn = buttons.find(btn => btn.textContent === "Ctrl+k")
+		expect(searchBtn).toBeTruthy()
+		act(() => searchBtn!.click())
+		expect(searchBtn!.textContent).toBe("Press a key…")
+		act(() => {
+			window.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "s",
+				ctrlKey: true,
+				bubbles: true,
+				cancelable: true,
+			}))
+		})
+		expect(JSON.parse(localStorage.getItem("gomuks-keybindings")!)).toEqual({
+			focus_room_search: "Ctrl+s",
+		})
+		expect(searchBtn!.textContent).toBe("Ctrl+s")
+	})
+
+	test("rejects reserved Enter and shows error", () => {
+		act(() => root.render(createElement(KeybindingsSettings)))
+		const buttons = [...container.querySelectorAll("button")]
+		const searchBtn = buttons.find(btn => btn.textContent === "Ctrl+k")
+		act(() => searchBtn!.click())
+		act(() => {
+			window.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "Enter",
+				bubbles: true,
+				cancelable: true,
+			}))
+		})
+		expect(container.querySelector(".keybind-error")?.textContent).toMatch(/reserved/)
+		expect(localStorage.getItem("gomuks-keybindings")).toBeNull()
+	})
+
+	test("reset to defaults clears storage", () => {
+		localStorage.setItem("gomuks-keybindings", JSON.stringify({ focus_room_search: "Ctrl+s" }))
+		act(() => root.render(createElement(KeybindingsSettings)))
+		const reset = [...container.querySelectorAll("button")].find(btn => btn.textContent === "Reset to defaults")
+		expect(reset).toBeTruthy()
+		act(() => reset!.click())
+		expect(localStorage.getItem("gomuks-keybindings")).toBeNull()
+		expect(container.textContent).toContain("Ctrl+k")
+	})
+})

--- a/web/src/ui/settings/KeybindingsSettings.tsx
+++ b/web/src/ui/settings/KeybindingsSettings.tsx
@@ -1,0 +1,106 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { useEffect, useState } from "react"
+import { keyToString } from "../keybindings.ts"
+import {
+	ACTION_LABELS,
+	ActionName,
+	BINDABLE_ACTIONS,
+	DEFAULT_KEYBINDINGS,
+	buildEffectiveKeymap,
+	clearKeybindOverrides,
+	loadKeybindOverrides,
+	saveKeybindOverrides,
+} from "../keyconfig.ts"
+
+function isModifierOnly(evt: KeyboardEvent): boolean {
+	return evt.key === "Control" || evt.key === "Shift" || evt.key === "Alt" || evt.key === "Meta"
+}
+
+const KeybindingsSettings = () => {
+	const [overrides, setOverrides] = useState<Record<string, string>>(loadKeybindOverrides)
+	const [recording, setRecording] = useState<ActionName | null>(null)
+	const [error, setError] = useState<string | null>(null)
+
+	const effective = buildEffectiveKeymap(overrides)
+
+	useEffect(() => {
+		if (!recording) {
+			return
+		}
+		const onKeyDown = (evt: KeyboardEvent) => {
+			if (isModifierOnly(evt)) {
+				return
+			}
+			evt.preventDefault()
+			evt.stopPropagation()
+			const key = keyToString(evt)
+			const next = { ...loadKeybindOverrides(), [recording]: key }
+			try {
+				saveKeybindOverrides(next)
+				setOverrides(next)
+				setError(null)
+				setRecording(null)
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err))
+				setRecording(null)
+			}
+		}
+		window.addEventListener("keydown", onKeyDown, true)
+		return () => window.removeEventListener("keydown", onKeyDown, true)
+	}, [recording])
+
+	const resetDefaults = () => {
+		clearKeybindOverrides()
+		setOverrides({})
+		setError(null)
+		setRecording(null)
+	}
+
+	return <div className="keybindings-settings">
+		<h3>Keyboard shortcuts</h3>
+		<p>
+			Click a shortcut, then press the new key. Enter and Tab stay reserved for the composer.
+			Reply shortcuts still require the “Use Ctrl+Arrow to reply” preference.
+		</p>
+		{error && <div className="keybind-error" role="alert">{error}</div>}
+		<div className="keybind-table">
+			<div className="name">Action</div>
+			<div className="name">Shortcut</div>
+			{BINDABLE_ACTIONS.map(action => [
+				<div className="name" key={`${action}-label`}>{ACTION_LABELS[action]}</div>,
+				<button
+					key={`${action}-key`}
+					className={recording === action ? "recording" : ""}
+					onClick={() => {
+						setError(null)
+						setRecording(action)
+					}}
+				>
+					{recording === action ? "Press a key…" : effective[action]}
+				</button>,
+			])}
+		</div>
+		<div className="keybind-actions">
+			<button onClick={resetDefaults} disabled={Object.keys(overrides).length === 0}>
+				Reset to defaults
+			</button>
+			<code>{DEFAULT_KEYBINDINGS.close_panel} closes panels first, then the room.</code>
+		</div>
+	</div>
+}
+
+export default KeybindingsSettings

--- a/web/src/ui/settings/SettingsView.css
+++ b/web/src/ui/settings/SettingsView.css
@@ -329,6 +329,55 @@ div.key-restore-modal-wrapper {
 	max-width: min(30rem, 90vw) !important;
 }
 
+div.settings-tab > div.keybindings-settings {
+	display: flex;
+	flex-direction: column;
+	gap: .75rem;
+	max-width: 36rem;
+
+	> p {
+		margin: 0;
+		color: var(--semisecondary-text-color);
+	}
+
+	> .keybind-error {
+		color: var(--error-color);
+	}
+
+	> .keybind-table {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: .25rem .75rem;
+		align-items: center;
+
+		> .name {
+			font-weight: bold;
+		}
+
+		> button {
+			font-family: var(--monospace-font-stack);
+			padding: .25rem .5rem;
+			min-width: 10rem;
+
+			&.recording {
+				background-color: var(--primary-color-dark);
+				color: var(--inverted-text-color);
+			}
+		}
+	}
+
+	> .keybind-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: .5rem;
+		align-items: center;
+
+		> button {
+			padding: .5rem 1rem;
+		}
+	}
+}
+
 div.key-restore-modal {
 	display: flex;
 	flex-direction: column;

--- a/web/src/ui/settings/SettingsView.tsx
+++ b/web/src/ui/settings/SettingsView.tsx
@@ -25,6 +25,7 @@ import ClientContext from "../ClientContext.ts"
 import BackendManager from "./BackendManager.tsx"
 import CustomCSSInput from "./CustomCSSInput.tsx"
 import EncryptionSettings from "./EncryptionSettings.tsx"
+import KeybindingsSettings from "./KeybindingsSettings.tsx"
 import MiscButtons from "./MiscButtons.tsx"
 import RoomSettings from "./RoomSettings.tsx"
 import SettingsDeck from "./SettingsDeck.tsx"
@@ -40,6 +41,7 @@ interface SettingsViewProps {
 enum SettingsTab {
 	RoomSettings,
 	Preferences,
+	Keybindings,
 	CustomCSS,
 	Encryption,
 	MiscButtons,
@@ -55,6 +57,8 @@ function getContent(tab: SettingsTab, setPref: SetPrefFunc, room?: RoomStateStor
 		return <RoomSettings room={room} />
 	case SettingsTab.Preferences:
 		return <SettingsDeck setPref={setPref} room={room} />
+	case SettingsTab.Keybindings:
+		return <KeybindingsSettings />
 	case SettingsTab.CustomCSS:
 		return <CustomCSSInput setPref={setPref} room={room} />
 	case SettingsTab.Encryption:
@@ -116,6 +120,7 @@ const SettingsView = ({ room }: SettingsViewProps) => {
 		<nav className="tabs">
 			{room && makeTabButton(SettingsTab.RoomSettings, "Room settings")}
 			{makeTabButton(SettingsTab.Preferences, "Preferences")}
+			{makeTabButton(SettingsTab.Keybindings, "Keybindings")}
 			{makeTabButton(SettingsTab.CustomCSS, "Custom CSS")}
 			{makeTabButton(SettingsTab.Encryption, "Encryption")}
 			{makeTabButton(SettingsTab.MiscButtons, "Misc buttons")}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,22 @@
+// NOTE: this file intentionally does not import `defineConfig` from "vitest/config".
+// vite 8.2.1's rolldown config bundler fails to externalize transitive `node:url`
+// imports from vitest/config ("Cannot find package 'node'" startup error), so the
+// config is a plain object with zero bundlable imports.
+export default {
+	test: {
+		environment: "jsdom",
+		include: ["src/**/*.test.{ts,tsx}"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json-summary", "lcov"],
+			include: ["src/util/**", "src/ui/keybindings.ts", "src/api/util/**", "src/ui/util/**"],
+			exclude: ["src/util/emoji/data.json", "src/util/emoji/generate.go", "src/util/**/*.css", "coverage/**"],
+			thresholds: { lines: 0, statements: 0, functions: 0, branches: 0 },
+		},
+	},
+	resolve: {
+		alias: {
+			"@": "/src",
+		},
+	},
+}


### PR DESCRIPTION
### Summary

This PR introduces user-configurable keybindings to the web client, along with an interactive reply selection shortcut for the terminal (TUI) client.

---

### Key Changes

#### 1. Web Client: Configurable Keybindings
- **Keybinding Engine & Validation** (`web/src/ui/keyconfig.ts`):
  - Manages keymap definitions with validation (guards reserved keys such as `Enter` and `Tab`, detects shortcut collisions).
  - Persists overrides in `localStorage` under `gomuks-keybindings`.
  - Dispatches a custom `gomuks-keybindings-changed` event for seamless hot-reloading across the UI without full page refresh.
- **Settings UI** (`web/src/ui/settings/KeybindingsSettings.tsx`):
  - Adds a new **Keybindings** tab in Settings.
  - Interactive key recorder to click an action and press the desired shortcut.
  - One-click "Reset to defaults" action.
- **Supported Bindable Actions**:
  - `close_panel` (default: `Escape`)
  - `focus_room_search` (default: `Ctrl+k`)
  - `next_room` (default: `Alt+ArrowUp`)
  - `prev_room` (default: `Alt+ArrowDown`)
  - `open_search` (default: `Ctrl+f`)
  - `reply_prev` (default: `Ctrl+ArrowUp`)
  - `reply_next` (default: `Ctrl+ArrowDown`)

#### 2. Terminal (TUI) Client: Reply Selection Hotkey
- Added `Ctrl+r` in room view (`tui/config/keybindings.yaml` / `tui/room-view.go`).
- Enters `SelectReply` mode: navigate messages with Arrow keys / `j`/`k` and hit `Enter` to reply.

#### 3. Testing
- Added comprehensive unit tests for keymap loading, validation, merging, event handling, and UI recording components (`web/src/ui/keyconfig.test.ts`, `web/src/ui/keybindings.test.ts`, `web/src/ui/settings/KeybindingsSettings.test.tsx`, `tui/find-message_test.go`).