### PR TITLE
feat(tui): Matrix Space (Workspace) switcher, room filtering, and fuzzy picker

### DIFF
--- a/pkg/rpc/store/space_test.go
+++ b/pkg/rpc/store/space_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package store_test
+
+import (
+	"slices"
+	"testing"
+
+	"go.mau.fi/util/ptr"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/pkg/hicli/jsoncmd"
+	"go.mau.fi/gomuks/pkg/rpc/store"
+)
+
+func spaceRoom(roomID id.RoomID, name string) *jsoncmd.SyncRoom {
+	return &jsoncmd.SyncRoom{Meta: &database.Room{
+		ID:              roomID,
+		Name:            ptr.Ptr(name),
+		CreationContent: &event.CreateEventContent{Type: event.RoomTypeSpace},
+	}}
+}
+
+func plainRoom(roomID id.RoomID, name string) *jsoncmd.SyncRoom {
+	return &jsoncmd.SyncRoom{Meta: &database.Room{
+		ID:   roomID,
+		Name: ptr.Ptr(name),
+	}}
+}
+
+const (
+	spaceA = id.RoomID("!spaceA:example.org")
+	spaceB = id.RoomID("!spaceB:example.org")
+	roomX  = id.RoomID("!roomX:example.org")
+	roomY  = id.RoomID("!roomY:example.org")
+)
+
+func newSyncedStore() *store.GomuksStore {
+	st := store.NewStore()
+	st.ApplySync(&jsoncmd.SyncComplete{
+		Rooms: map[id.RoomID]*jsoncmd.SyncRoom{
+			spaceA: spaceRoom(spaceA, "Beta Space"),
+			spaceB: spaceRoom(spaceB, "Alpha Space"),
+			roomX:  plainRoom(roomX, "Room X"),
+			roomY:  plainRoom(roomY, "Room Y"),
+		},
+		SpaceEdges: map[id.RoomID][]*database.SpaceEdge{
+			spaceA: {{ChildID: roomX}},
+			spaceB: {{ChildID: roomY}},
+		},
+	})
+	return st
+}
+
+func spaceNames(spaces []*store.SpaceEntry) []string {
+	names := make([]string, len(spaces))
+	for i, sp := range spaces {
+		names[i] = sp.Name
+	}
+	return names
+}
+
+func TestGetSpaceList_EmptyBeforeSync(t *testing.T) {
+	if got := store.NewStore().GetSpaceList(); len(got) != 0 {
+		t.Errorf("expected no spaces before sync, got %d", len(got))
+	}
+}
+
+func TestGetSpaceList_OnlySpacesSortedByName(t *testing.T) {
+	got := spaceNames(newSyncedStore().GetSpaceList())
+	want := []string{"Alpha Space", "Beta Space"}
+	if !slices.Equal(got, want) {
+		t.Errorf("expected spaces %v (regular rooms excluded), got %v", want, got)
+	}
+}
+
+func TestIsRoomInSpace(t *testing.T) {
+	st := newSyncedStore()
+	cases := []struct {
+		space id.RoomID
+		room  id.RoomID
+		want  bool
+	}{
+		{spaceA, roomX, true},
+		{spaceA, roomY, false},
+		{spaceB, roomY, true},
+		{spaceB, roomX, false},
+	}
+	for _, tc := range cases {
+		if got := st.IsRoomInSpace(tc.space, tc.room); got != tc.want {
+			t.Errorf("IsRoomInSpace(%s, %s) = %v, want %v", tc.space, tc.room, got, tc.want)
+		}
+	}
+}
+
+func TestGetRoomsInSpace(t *testing.T) {
+	st := newSyncedStore()
+	if got := st.GetRoomsInSpace(spaceA); !slices.Equal(got, []id.RoomID{roomX}) {
+		t.Errorf("expected space A to contain only room X, got %v", got)
+	}
+	if got := st.GetRoomsInSpace("!nonexistent:example.org"); len(got) != 0 {
+		t.Errorf("expected no rooms for unknown space, got %v", got)
+	}
+}
+
+func TestApplySync_LeavingSpaceDropsItsEdges(t *testing.T) {
+	st := newSyncedStore()
+	st.ApplySync(&jsoncmd.SyncComplete{LeftRooms: []id.RoomID{spaceA}})
+
+	if st.IsRoomInSpace(spaceA, roomX) {
+		t.Error("expected edges of the left space to be dropped")
+	}
+	if got := spaceNames(st.GetSpaceList()); !slices.Equal(got, []string{"Alpha Space"}) {
+		t.Errorf("expected only the remaining space, got %v", got)
+	}
+}
+
+func TestApplySync_EmptyEdgeListRemovesSpaceChildren(t *testing.T) {
+	st := newSyncedStore()
+	// The backend resends the full edge list per space, so an empty list means
+	// the space has no children anymore.
+	st.ApplySync(&jsoncmd.SyncComplete{
+		SpaceEdges: map[id.RoomID][]*database.SpaceEdge{spaceA: {}},
+	})
+
+	if st.IsRoomInSpace(spaceA, roomX) {
+		t.Error("expected an empty edge list to clear the space's children")
+	}
+}
+
+func TestClear_RemovesSpaces(t *testing.T) {
+	st := newSyncedStore()
+	st.Clear()
+
+	if got := st.GetSpaceList(); len(got) != 0 {
+		t.Errorf("expected no spaces after Clear, got %d", len(got))
+	}
+	if st.IsRoomInSpace(spaceB, roomY) {
+		t.Error("expected space edges to be cleared")
+	}
+}
+
+func TestApplySync_LeavingChildRoomRemovesEdgeFromParent(t *testing.T) {
+	st := newSyncedStore()
+	if !st.IsRoomInSpace(spaceA, roomX) {
+		t.Fatal("precondition failed: roomX should be in spaceA")
+	}
+
+	st.ApplySync(&jsoncmd.SyncComplete{LeftRooms: []id.RoomID{roomX}})
+
+	if st.IsRoomInSpace(spaceA, roomX) {
+		t.Error("expected roomX to be removed from spaceA edges after being left")
+	}
+	if got := st.GetRoomsInSpace(spaceA); len(got) != 0 {
+		t.Errorf("expected spaceA to have no rooms, got %v", got)
+	}
+}
+
+func TestGetSpaceList_UnnamedSpaceFallback(t *testing.T) {
+	unnamedSpaceID := id.RoomID("!unnamed:example.org")
+	st := store.NewStore()
+	st.ApplySync(&jsoncmd.SyncComplete{
+		Rooms: map[id.RoomID]*jsoncmd.SyncRoom{
+			unnamedSpaceID: {
+				Meta: &database.Room{
+					ID:              unnamedSpaceID,
+					CreationContent: &event.CreateEventContent{Type: event.RoomTypeSpace},
+				},
+			},
+		},
+	})
+
+	spaces := st.GetSpaceList()
+	if len(spaces) != 1 {
+		t.Fatalf("expected 1 space, got %d", len(spaces))
+	}
+	if spaces[0].Name != string(unnamedSpaceID) {
+		t.Errorf("expected fallback name %q, got %q", string(unnamedSpaceID), spaces[0].Name)
+	}
+}

--- a/pkg/rpc/store/store.go
+++ b/pkg/rpc/store/store.go
@@ -9,6 +9,7 @@ package store
 import (
 	"encoding/json"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +47,14 @@ type GomuksStore struct {
 	accountData      map[event.Type]*database.AccountData
 	AccountDataSubs  MultiNotifier[event.Type]
 	PreferenceCache  EventDispatcher[*Preferences]
+	spaceEdges       map[id.RoomID][]*database.SpaceEdge
+	SpaceList        EventDispatcher[[]*SpaceEntry]
+}
+
+// SpaceEntry is a space shown in the space switcher.
+type SpaceEntry struct {
+	RoomID id.RoomID
+	Name   string
 }
 
 func NewStore() *GomuksStore {
@@ -53,6 +62,7 @@ func NewStore() *GomuksStore {
 		rooms:        make(map[id.RoomID]*RoomStore),
 		invitedRooms: make(map[id.RoomID]*InvitedRoom),
 		accountData:  make(map[event.Type]*database.AccountData),
+		spaceEdges:   make(map[id.RoomID][]*database.SpaceEdge),
 	}
 	return gs
 }
@@ -121,6 +131,7 @@ func (gs *GomuksStore) ApplySync(sync *jsoncmd.SyncComplete) {
 	defer gs.lock.Unlock()
 	resyncRoomList := len(gs.roomList) == 0
 	changedRoomListEntries := make(map[id.RoomID]*RoomListEntry)
+	spacesChanged := false
 	for evtType, ad := range sync.AccountData {
 		evtType.Class = event.AccountDataEventType
 		if evtType == AccountDataGomuksPreferences {
@@ -156,7 +167,29 @@ func (gs *GomuksStore) ApplySync(sync *jsoncmd.SyncComplete) {
 	}
 	for _, roomID := range sync.LeftRooms {
 		delete(gs.rooms, roomID)
+		delete(gs.spaceEdges, roomID)
+		for parentSpaceID, edges := range gs.spaceEdges {
+			filtered := slices.DeleteFunc(edges, func(edge *database.SpaceEdge) bool {
+				return edge.ChildID == roomID
+			})
+			if len(filtered) == 0 {
+				delete(gs.spaceEdges, parentSpaceID)
+			} else {
+				gs.spaceEdges[parentSpaceID] = filtered
+			}
+		}
 		changedRoomListEntries[roomID] = nil
+	}
+
+	if len(sync.SpaceEdges) > 0 {
+		for spaceID, edges := range sync.SpaceEdges {
+			if len(edges) == 0 {
+				delete(gs.spaceEdges, spaceID)
+			} else {
+				gs.spaceEdges[spaceID] = edges
+			}
+		}
+		spacesChanged = true
 	}
 	var updatedRoomList []*RoomListEntry
 	if resyncRoomList {
@@ -204,6 +237,63 @@ func (gs *GomuksStore) ApplySync(sync *jsoncmd.SyncComplete) {
 		slices.Reverse(reversed)
 		gs.ReversedRoomList.Emit(reversed)
 	}
+	// A room becoming (or ceasing to be) a space changes the switcher contents
+	// even when no m.space.child edges moved.
+	if spacesChanged || updatedRoomList != nil {
+		gs.SpaceList.Emit(gs.buildSpaceList())
+	}
+}
+
+// buildSpaceList returns the joined spaces, sorted by name. Callers must hold
+// at least a read lock.
+func (gs *GomuksStore) buildSpaceList() []*SpaceEntry {
+	spaces := make([]*SpaceEntry, 0, len(gs.spaceEdges))
+	for _, roomStore := range gs.rooms {
+		meta := roomStore.Meta.Current()
+		if meta.GetType() != event.RoomTypeSpace {
+			continue
+		}
+		name := ptr.Val(meta.Name)
+		if name == "" {
+			name = string(meta.ID)
+		}
+		spaces = append(spaces, &SpaceEntry{
+			RoomID: meta.ID,
+			Name:   name,
+		})
+	}
+	slices.SortFunc(spaces, func(a, b *SpaceEntry) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return spaces
+}
+
+// GetSpaceList returns the joined spaces, sorted by name.
+func (gs *GomuksStore) GetSpaceList() []*SpaceEntry {
+	gs.lock.RLock()
+	defer gs.lock.RUnlock()
+	return gs.buildSpaceList()
+}
+
+// IsRoomInSpace reports whether the given room is a direct child of the space.
+func (gs *GomuksStore) IsRoomInSpace(spaceID, roomID id.RoomID) bool {
+	gs.lock.RLock()
+	defer gs.lock.RUnlock()
+	return slices.ContainsFunc(gs.spaceEdges[spaceID], func(edge *database.SpaceEdge) bool {
+		return edge.ChildID == roomID
+	})
+}
+
+// GetRoomsInSpace returns the room IDs that are direct children of the space.
+func (gs *GomuksStore) GetRoomsInSpace(spaceID id.RoomID) []id.RoomID {
+	gs.lock.RLock()
+	defer gs.lock.RUnlock()
+	edges := gs.spaceEdges[spaceID]
+	rooms := make([]id.RoomID, 0, len(edges))
+	for _, edge := range edges {
+		rooms = append(rooms, edge.ChildID)
+	}
+	return rooms
 }
 
 func (gs *GomuksStore) GetRoom(roomID id.RoomID) *RoomStore {
@@ -224,7 +314,9 @@ func (gs *GomuksStore) Clear() {
 	clear(gs.rooms)
 	clear(gs.invitedRooms)
 	clear(gs.accountData)
+	clear(gs.spaceEdges)
 	gs.PreferenceCache.Emit(nil)
 	gs.roomList = nil
 	gs.ReversedRoomList.Emit([]*RoomListEntry{})
+	gs.SpaceList.Emit([]*SpaceEntry{})
 }

--- a/tui/config/config.go
+++ b/tui/config/config.go
@@ -192,7 +192,8 @@ func parseKeybindings(input map[string]string) (output map[Keybind]string) {
 	for shortcut, action := range input {
 		mod, key, ch, err := cbind.Decode(shortcut)
 		if err != nil {
-			panic(fmt.Errorf("failed to parse keybinding %s -> %s: %w", shortcut, action, err))
+			debug.Printf("Skipping invalid keybinding %s -> %s: %v", shortcut, action, err)
+			continue
 		}
 		// TODO find out if other keys are parsed incorrectly like this
 		if key == tcell.KeyEscape {

--- a/tui/config/keybindings.yaml
+++ b/tui/config/keybindings.yaml
@@ -14,6 +14,12 @@ main:
     'Alt+Enter': add_newline
     'Alt+a': next_active_room
     'Alt+l': show_bare
+    'Ctrl+s': search_spaces
+    'Alt+s': search_spaces
+    'Ctrl+]': next_space
+    'Ctrl+[': prev_space
+    'Alt+]': next_space
+    'Alt+[': prev_space
     'Ctrl+c': force_quit
 
 modal:
@@ -40,4 +46,8 @@ room:
     'Ctrl+n': scroll_down
     'PageUp': scroll_up
     'PageDown': scroll_down
+    'Ctrl+r': reply
+    'Alt+r': react
+    'Alt+Delete': redact
+    'Alt+c': copy
     'Enter': send

--- a/tui/config/keybindings_test.go
+++ b/tui/config/keybindings_test.go
@@ -1,0 +1,172 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func newTestConfig(t *testing.T) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := NewConfig()
+	cfg.Dir = dir
+	cfg.nosave = true
+	return cfg
+}
+
+func writeKeybindingsFile(t *testing.T, cfg *Config, content string) {
+	t.Helper()
+	path := filepath.Join(cfg.Dir, "terminal-keybindings.yaml")
+	if err := os.MkdirAll(cfg.Dir, 0700); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write keybindings: %v", err)
+	}
+}
+
+func TestParseKeybindings_Defaults(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.LoadKeybindings()
+
+	cases := []struct {
+		name   string
+		binds  map[Keybind]string
+		key    Keybind
+		action string
+	}{
+		{
+			name:   "Ctrl+k opens room search",
+			binds:  cfg.Keybindings.Main,
+			key:    Keybind{Mod: tcell.ModCtrl, Key: tcell.KeyCtrlK, Ch: 11},
+			action: "search_rooms",
+		},
+		{
+			name:   "Enter confirms in modal",
+			binds:  cfg.Keybindings.Modal,
+			key:    Keybind{Key: tcell.KeyEnter, Ch: 13},
+			action: "confirm",
+		},
+		{
+			name:   "Enter sends in room",
+			binds:  cfg.Keybindings.Room,
+			key:    Keybind{Key: tcell.KeyEnter, Ch: 13},
+			action: "send",
+		},
+		{
+			name:   "j selects next in visual mode",
+			binds:  cfg.Keybindings.Visual,
+			key:    Keybind{Key: tcell.KeyRune, Ch: 'j'},
+			action: "select_next",
+		},
+		{
+			name:   "Ctrl+r starts a reply",
+			binds:  cfg.Keybindings.Room,
+			key:    Keybind{Mod: tcell.ModCtrl, Key: tcell.KeyCtrlR, Ch: 18},
+			action: "reply",
+		},
+		{
+			name:   "Alt+r starts a reaction",
+			binds:  cfg.Keybindings.Room,
+			key:    Keybind{Mod: tcell.ModAlt, Key: tcell.KeyRune, Ch: 'r'},
+			action: "react",
+		},
+		{
+			name:   "Alt+c starts a copy",
+			binds:  cfg.Keybindings.Room,
+			key:    Keybind{Mod: tcell.ModAlt, Key: tcell.KeyRune, Ch: 'c'},
+			action: "copy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.binds[tc.key]; got != tc.action {
+				t.Errorf("expected action %q, got %q", tc.action, got)
+			}
+		})
+	}
+}
+
+func TestParseKeybindings_EscapeClearsRune(t *testing.T) {
+	// Escape decodes with a stray rune; the parser must zero it so lookups by
+	// KeyEscape with Ch==0 match what tcell delivers at runtime.
+	out := parseKeybindings(map[string]string{"Escape": "cancel"})
+	if got := out[Keybind{Key: tcell.KeyEscape, Ch: 0}]; got != "cancel" {
+		t.Errorf("expected Escape to map to cancel with zeroed rune, got %q", got)
+	}
+}
+
+func TestParseKeybindings_InvalidShortcutIsSkipped(t *testing.T) {
+	// A typo in a user's keybindings file must not take down the client.
+	out := parseKeybindings(map[string]string{
+		"Ctrl+k":          "search_rooms",
+		"NotARealKey+Zzz": "explode",
+	})
+	// Valid bindings must survive an invalid one.
+	if got := out[Keybind{Mod: tcell.ModCtrl, Key: tcell.KeyCtrlK, Ch: 11}]; got != "search_rooms" {
+		t.Errorf("expected valid binding to survive, got %q", got)
+	}
+	// Invalid binding must be absent from the map.
+	for kb, action := range out {
+		if action == "explode" {
+			t.Errorf("invalid binding was not skipped: %+v -> %s", kb, action)
+		}
+	}
+}
+
+func TestLoadKeybindings_UserOverridesDefaults(t *testing.T) {
+	cfg := newTestConfig(t)
+	writeKeybindingsFile(t, cfg, "main:\n    'Ctrl+g': search_rooms\n")
+	cfg.LoadKeybindings()
+
+	if got := cfg.Keybindings.Main[Keybind{Mod: tcell.ModCtrl, Key: tcell.KeyCtrlG, Ch: 7}]; got != "search_rooms" {
+		t.Errorf("expected user binding Ctrl+g to be applied, got %q", got)
+	}
+}
+
+func TestLoadKeybindings_UserFileKeepsUntouchedSections(t *testing.T) {
+	cfg := newTestConfig(t)
+	writeKeybindingsFile(t, cfg, "main:\n    'Ctrl+g': search_rooms\n")
+	cfg.LoadKeybindings()
+
+	// Overriding `main` must not wipe the default `modal` bindings.
+	if got := cfg.Keybindings.Modal[Keybind{Key: tcell.KeyEnter, Ch: 13}]; got != "confirm" {
+		t.Errorf("expected default modal binding to survive, got %q", got)
+	}
+}
+
+func TestLoadKeybindings_MalformedFileDoesNotPanic(t *testing.T) {
+	cfg := newTestConfig(t)
+	writeKeybindingsFile(t, cfg, "main:\n    'TotallyBogus+!!': nonsense\n")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("LoadKeybindings panicked on a malformed user file: %v", r)
+		}
+	}()
+	cfg.LoadKeybindings()
+
+	// Defaults must still be usable after rejecting the bad entry.
+	if got := cfg.Keybindings.Modal[Keybind{Key: tcell.KeyEnter, Ch: 13}]; got != "confirm" {
+		t.Errorf("expected defaults to remain loaded, got %q", got)
+	}
+}

--- a/tui/find-message.go
+++ b/tui/find-message.go
@@ -1,0 +1,81 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2025 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"maunium.net/go/mautrix/event"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/tui/messages"
+)
+
+type findFilter func(evt *database.Event) bool
+
+func isLocalEcho(evt *database.Event) bool {
+	if evt == nil || evt.ID == "" {
+		return true
+	}
+	return evt.TransactionID != "" && string(evt.ID) == evt.TransactionID
+}
+
+func asUIMessage(evt *database.Event) *messages.UIMessage {
+	if evt == nil || evt.RenderMeta == nil {
+		return nil
+	}
+	uiMsg, ok := evt.RenderMeta.(*messages.UIMessage)
+	if !ok || uiMsg == nil || uiMsg.IsService {
+		return nil
+	}
+	return uiMsg
+}
+
+func selectAllowed(evt *database.Event) bool {
+	if evt == nil || isLocalEcho(evt) {
+		return false
+	}
+	return evt.GetType() == event.EventMessage
+}
+
+func findMessageInTimeline(timeline []*database.Event, current *database.Event, forward bool, allow findFilter) *messages.UIMessage {
+	if len(timeline) == 0 {
+		return nil
+	}
+
+	currentFound := current == nil
+	for i := 0; i < len(timeline); i++ {
+		index := i
+		if !forward {
+			index = len(timeline) - i - 1
+		}
+		evt := timeline[index]
+		if isLocalEcho(evt) {
+			continue
+		}
+		uiMsg := asUIMessage(evt)
+		if uiMsg == nil {
+			continue
+		}
+		if currentFound {
+			if allow == nil || allow(evt) {
+				return uiMsg
+			}
+		} else if current != nil && evt.ID == current.ID {
+			currentFound = true
+		}
+	}
+	return nil
+}

--- a/tui/find-message_test.go
+++ b/tui/find-message_test.go
@@ -1,0 +1,114 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2025 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/tui/messages"
+)
+
+func makeTimelineEvent(eventID string, evtType string, txn string, service bool) *database.Event {
+	evt := &database.Event{
+		ID:            id.EventID(eventID),
+		Type:          evtType,
+		TransactionID: txn,
+	}
+	evt.RenderMeta = &messages.UIMessage{
+		Event:     evt,
+		IsService: service,
+	}
+	return evt
+}
+
+func TestFindMessageInTimeline_emptyAndNil(t *testing.T) {
+	if got := findMessageInTimeline(nil, nil, false, selectAllowed); got != nil {
+		t.Fatalf("nil timeline: got %v", got)
+	}
+	if got := findMessageInTimeline([]*database.Event{}, nil, false, selectAllowed); got != nil {
+		t.Fatalf("empty timeline: got %v", got)
+	}
+}
+
+func TestFindMessageInTimeline_skipsLocalEchoAndService(t *testing.T) {
+	echo := makeTimelineEvent("$echo", event.EventMessage.Type, "$echo", false)
+	notice := makeTimelineEvent("$svc", event.EventMessage.Type, "", true)
+	ok := makeTimelineEvent("$ok", event.EventMessage.Type, "", false)
+	member := makeTimelineEvent("$member", event.StateMember.Type, "", false)
+
+	got := findMessageInTimeline([]*database.Event{echo, notice, member, ok}, nil, false, selectAllowed)
+	if got == nil || got.ID != "$ok" {
+		t.Fatalf("expected $ok from end, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_previousFromNilSelectsLastAllowed(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+
+	got := findMessageInTimeline([]*database.Event{a, b, c}, nil, false, selectAllowed)
+	if got == nil || got.ID != "$c" {
+		t.Fatalf("expected last message $c, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_previousFromCurrent(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+	timeline := []*database.Event{a, b, c}
+
+	got := findMessageInTimeline(timeline, c, false, selectAllowed)
+	if got == nil || got.ID != "$b" {
+		t.Fatalf("expected $b before $c, got %#v", got)
+	}
+	got = findMessageInTimeline(timeline, a, false, selectAllowed)
+	if got != nil {
+		t.Fatalf("expected nil before first, got %#v", got)
+	}
+}
+
+func TestFindMessageInTimeline_nextFromCurrent(t *testing.T) {
+	a := makeTimelineEvent("$a", event.EventMessage.Type, "", false)
+	b := makeTimelineEvent("$b", event.EventMessage.Type, "", false)
+	c := makeTimelineEvent("$c", event.EventMessage.Type, "", false)
+	timeline := []*database.Event{a, b, c}
+
+	got := findMessageInTimeline(timeline, a, true, selectAllowed)
+	if got == nil || got.ID != "$b" {
+		t.Fatalf("expected $b after $a, got %#v", got)
+	}
+	got = findMessageInTimeline(timeline, c, true, selectAllowed)
+	if got != nil {
+		t.Fatalf("expected nil after last, got %#v", got)
+	}
+}
+
+func TestSelectAllowed_rejectsNonMessage(t *testing.T) {
+	evt := makeTimelineEvent("$m", event.StateMember.Type, "", false)
+	if selectAllowed(evt) {
+		t.Fatal("state events must not be reply targets")
+	}
+	if selectAllowed(nil) {
+		t.Fatal("nil must not be allowed")
+	}
+}

--- a/tui/fuzzy-picker-modal.go
+++ b/tui/fuzzy-picker-modal.go
@@ -1,0 +1,169 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/lithammer/fuzzysearch/fuzzy"
+	"go.mau.fi/mauview"
+
+	"go.mau.fi/gomuks/tui/config"
+)
+
+type FuzzyPickerModal struct {
+	mauview.Component
+
+	container *mauview.Box
+
+	search  *mauview.InputArea
+	results *mauview.TextView
+
+	matches  fuzzy.Ranks
+	selected int
+
+	titles   []string
+	onSelect func(index int)
+
+	parent *MainView
+}
+
+func NewFuzzyPickerModal(mainView *MainView, title string, titles []string, onSelect func(index int), width int, height int) *FuzzyPickerModal {
+	fp := &FuzzyPickerModal{
+		parent:   mainView,
+		titles:   titles,
+		onSelect: onSelect,
+	}
+
+	fp.results = mauview.NewTextView().SetRegions(true)
+	fp.search = mauview.NewInputArea().
+		SetChangedFunc(fp.changeHandler).
+		SetTextColor(tcell.ColorWhite).
+		SetBackgroundColor(tcell.ColorDarkCyan)
+	fp.search.Focus()
+
+	flex := mauview.NewFlex().
+		SetDirection(mauview.FlexRow).
+		AddFixedComponent(fp.search, 1).
+		AddProportionalComponent(fp.results, 1)
+
+	fp.container = mauview.NewBox(flex).
+		SetBorder(true).
+		SetTitle(title).
+		SetBlurCaptureFunc(func() bool {
+			fp.parent.HideModal()
+			return true
+		})
+
+	fp.Component = mauview.Center(fp.container, width, height).SetAlwaysFocusChild(true)
+	fp.changeHandler("")
+
+	return fp
+}
+
+func (fp *FuzzyPickerModal) Focus() {
+	fp.container.Focus()
+}
+
+func (fp *FuzzyPickerModal) Blur() {
+	fp.container.Blur()
+}
+
+func (fp *FuzzyPickerModal) changeHandler(str string) {
+	if len(str) == 0 {
+		fp.matches = make(fuzzy.Ranks, len(fp.titles))
+		for i, title := range fp.titles {
+			fp.matches[i] = fuzzy.Rank{
+				Source:        "",
+				Target:        title,
+				OriginalIndex: i,
+				Distance:      0,
+			}
+		}
+		fp.results.Clear()
+		for _, match := range fp.matches {
+			_, _ = fmt.Fprintf(fp.results, `["%d"]%s[""]%s`, match.OriginalIndex, match.Target, "\n")
+		}
+		if len(fp.matches) > 0 {
+			fp.results.Highlight(strconv.Itoa(fp.matches[0].OriginalIndex))
+			fp.selected = 0
+			fp.results.ScrollToBeginning()
+		} else {
+			fp.results.Highlight()
+		}
+		return
+	}
+
+	fp.matches = fuzzy.RankFindFold(str, fp.titles)
+	if len(fp.matches) > 0 {
+		sort.Sort(fp.matches)
+		fp.results.Clear()
+		for _, match := range fp.matches {
+			_, _ = fmt.Fprintf(fp.results, `["%d"]%s[""]%s`, match.OriginalIndex, match.Target, "\n")
+		}
+		fp.results.Highlight(strconv.Itoa(fp.matches[0].OriginalIndex))
+		fp.selected = 0
+		fp.results.ScrollToBeginning()
+	} else {
+		fp.results.Clear()
+		fp.results.Highlight()
+	}
+}
+
+
+func (fp *FuzzyPickerModal) OnKeyEvent(event mauview.KeyEvent) bool {
+	highlights := fp.results.GetHighlights()
+	kb := config.Keybind{
+		Key: event.Key(),
+		Ch:  event.Rune(),
+		Mod: event.Modifiers(),
+	}
+	switch fp.parent.config.Keybindings.Modal[kb] {
+	case "cancel":
+		fp.parent.HideModal()
+		return true
+	case "select_next":
+		if len(highlights) > 0 {
+			fp.selected = (fp.selected + 1) % len(fp.matches)
+			fp.results.Highlight(strconv.Itoa(fp.matches[fp.selected].OriginalIndex))
+			fp.results.ScrollToHighlight()
+		}
+		return true
+	case "select_prev":
+		if len(highlights) > 0 {
+			fp.selected = (fp.selected - 1) % len(fp.matches)
+			if fp.selected < 0 {
+				fp.selected += len(fp.matches)
+			}
+			fp.results.Highlight(strconv.Itoa(fp.matches[fp.selected].OriginalIndex))
+			fp.results.ScrollToHighlight()
+		}
+		return true
+	case "confirm":
+		if len(highlights) > 0 && fp.onSelect != nil {
+			fp.onSelect(fp.matches[fp.selected].OriginalIndex)
+		}
+		fp.parent.HideModal()
+		fp.results.Clear()
+		fp.search.SetText("")
+		return true
+	}
+	return fp.search.OnKeyEvent(event)
+}

--- a/tui/fuzzy_picker_test.go
+++ b/tui/fuzzy_picker_test.go
@@ -1,0 +1,176 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+
+	"go.mau.fi/gomuks/tui/config"
+)
+
+func TestFuzzyPickerModal_SearchAndNavigation(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.LoadKeybindings()
+
+	mainView := &MainView{
+		config: cfg,
+	}
+
+	titles := []string{"General", "Random", "Development", "Announcements"}
+	var selectedIndex int = -1
+
+	picker := NewFuzzyPickerModal(mainView, "Test Picker", titles, func(index int) {
+		selectedIndex = index
+	}, 40, 10)
+
+	// Search for "Dev"
+	picker.changeHandler("Dev")
+	if len(picker.matches) != 1 {
+		t.Fatalf("expected 1 match for 'Dev', got %d", len(picker.matches))
+	}
+	if picker.matches[0].OriginalIndex != 2 {
+		t.Errorf("expected original index 2 ('Development'), got %d", picker.matches[0].OriginalIndex)
+	}
+
+	// Confirm selection
+	enterEvt := tcell.NewEventKey(tcell.KeyEnter, 13, 0)
+	handled := picker.OnKeyEvent(enterEvt)
+	if !handled {
+		t.Error("expected Enter key event to be handled")
+	}
+	if selectedIndex != 2 {
+		t.Errorf("expected callback with index 2, got %d", selectedIndex)
+	}
+}
+
+func TestFuzzyPickerModal_CycleMatches(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.LoadKeybindings()
+
+	mainView := &MainView{
+		config: cfg,
+	}
+
+	titles := []string{"Alpha", "Alphabet", "Alpine"}
+	var selectedIndex int = -1
+
+	picker := NewFuzzyPickerModal(mainView, "Test Picker", titles, func(index int) {
+		selectedIndex = index
+	}, 40, 10)
+
+	picker.changeHandler("Al")
+	if len(picker.matches) != 3 {
+		t.Fatalf("expected 3 matches for 'Al', got %d", len(picker.matches))
+	}
+
+	// Next
+	downEvt := tcell.NewEventKey(tcell.KeyDown, 0, 0)
+	picker.OnKeyEvent(downEvt)
+	if picker.selected != 1 {
+		t.Errorf("expected selected index 1, got %d", picker.selected)
+	}
+
+	// Next again
+	picker.OnKeyEvent(downEvt)
+	if picker.selected != 2 {
+		t.Errorf("expected selected index 2, got %d", picker.selected)
+	}
+
+	// Prev
+	upEvt := tcell.NewEventKey(tcell.KeyUp, 0, 0)
+	picker.OnKeyEvent(upEvt)
+	if picker.selected != 1 {
+		t.Errorf("expected selected index 1, got %d", picker.selected)
+	}
+
+	// Confirm
+	expectedIndex := picker.matches[picker.selected].OriginalIndex
+	enterEvt := tcell.NewEventKey(tcell.KeyEnter, 13, 0)
+	picker.OnKeyEvent(enterEvt)
+	if selectedIndex != expectedIndex {
+		t.Errorf("expected selected item %d, got %d", expectedIndex, selectedIndex)
+	}
+}
+
+func TestFuzzyPickerModal_InitialPopulate(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.LoadKeybindings()
+
+	mainView := &MainView{
+		config: cfg,
+	}
+
+	titles := []string{"All Rooms", "Work Space", "Community", "Gaming"}
+	var selectedIndex int = -1
+
+	picker := NewFuzzyPickerModal(mainView, "Space Switcher", titles, func(index int) {
+		selectedIndex = index
+	}, 40, 10)
+
+	// Initially with query "", all 4 items should be listed
+	if len(picker.matches) != 4 {
+		t.Fatalf("expected 4 matches initially on empty query, got %d", len(picker.matches))
+	}
+	if picker.selected != 0 {
+		t.Errorf("expected initially selected index 0, got %d", picker.selected)
+	}
+	if picker.matches[0].Target != "All Rooms" {
+		t.Errorf("expected first item to be 'All Rooms', got %q", picker.matches[0].Target)
+	}
+
+	// Immediate Enter on open selects the first item ("All Rooms")
+	enterEvt := tcell.NewEventKey(tcell.KeyEnter, 13, 0)
+	picker.OnKeyEvent(enterEvt)
+	if selectedIndex != 0 {
+		t.Errorf("expected selectedIndex 0 on initial Enter, got %d", selectedIndex)
+	}
+}
+
+func TestFuzzyPickerModal_FilterAndRestoreAll(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.LoadKeybindings()
+
+	mainView := &MainView{
+		config: cfg,
+	}
+
+	titles := []string{"All Rooms", "Work Space", "Community", "Gaming"}
+
+	picker := NewFuzzyPickerModal(mainView, "Space Switcher", titles, nil, 40, 10)
+
+	// Filter down to 1 item
+	picker.changeHandler("Gaming")
+	if len(picker.matches) != 1 {
+		t.Fatalf("expected 1 match for 'Gaming', got %d", len(picker.matches))
+	}
+	if picker.matches[0].Target != "Gaming" {
+		t.Errorf("expected match to be 'Gaming', got %q", picker.matches[0].Target)
+	}
+
+	// Backspace / clear query restores all 4 items
+	picker.changeHandler("")
+	if len(picker.matches) != 4 {
+		t.Fatalf("expected 4 matches after clearing query, got %d", len(picker.matches))
+	}
+	if picker.matches[0].Target != "All Rooms" {
+		t.Errorf("expected first item to be 'All Rooms', got %q", picker.matches[0].Target)
+	}
+}
+
+

--- a/tui/room-list.go
+++ b/tui/room-list.go
@@ -35,8 +35,9 @@ type RoomList struct {
 
 	parent *MainView
 
-	rooms    []*store.RoomListEntry
-	selected id.RoomID
+	rooms       []*store.RoomListEntry
+	activeSpace id.RoomID
+	selected    id.RoomID
 
 	scrollOffset int
 	height       int
@@ -84,9 +85,39 @@ func (list *RoomList) SelectedRoom() id.RoomID {
 	return list.selected
 }
 
-func (list *RoomList) Previous() id.RoomID {
+func (list *RoomList) updateRoomsLocked() {
+	allRooms := list.parent.matrix.ReversedRoomList.Current()
+	if list.activeSpace == "" {
+		list.rooms = allRooms
+		return
+	}
+	filtered := make([]*store.RoomListEntry, 0, len(allRooms))
+	for _, room := range allRooms {
+		if list.parent.matrix.IsRoomInSpace(list.activeSpace, room.RoomID) {
+			filtered = append(filtered, room)
+		}
+	}
+	list.rooms = filtered
+}
+
+func (list *RoomList) SetActiveSpace(spaceID id.RoomID) {
+	list.lock.Lock()
+	defer list.lock.Unlock()
+	list.activeSpace = spaceID
+	list.updateRoomsLocked()
+	list.scrollOffset = 0
+}
+
+func (list *RoomList) GetActiveSpace() id.RoomID {
 	list.lock.RLock()
 	defer list.lock.RUnlock()
+	return list.activeSpace
+}
+
+func (list *RoomList) Previous() id.RoomID {
+	list.lock.Lock()
+	defer list.lock.Unlock()
+	list.updateRoomsLocked()
 	idx := list.index(list.selected)
 	if idx > 0 && idx < len(list.rooms) {
 		return list.rooms[idx-1].RoomID
@@ -95,8 +126,9 @@ func (list *RoomList) Previous() id.RoomID {
 }
 
 func (list *RoomList) Next() id.RoomID {
-	list.lock.RLock()
-	defer list.lock.RUnlock()
+	list.lock.Lock()
+	defer list.lock.Unlock()
+	list.updateRoomsLocked()
 	if len(list.rooms) == 0 {
 		return ""
 	}
@@ -111,8 +143,9 @@ func (list *RoomList) Next() id.RoomID {
 }
 
 func (list *RoomList) NextWithActivity() id.RoomID {
-	list.lock.RLock()
-	defer list.lock.RUnlock()
+	list.lock.Lock()
+	defer list.lock.Unlock()
+	list.updateRoomsLocked()
 	for _, room := range list.rooms {
 		if room.UnreadHighlights > 0 || room.UnreadMessages > 0 || room.MarkedUnread {
 			return room.RoomID
@@ -175,7 +208,7 @@ func (list *RoomList) Blur()  {}
 
 func (list *RoomList) Draw(screen mauview.Screen) {
 	list.lock.Lock()
-	list.rooms = list.parent.matrix.ReversedRoomList.Current()
+	list.updateRoomsLocked()
 	list.width, list.height = screen.Size()
 	roomSlice := list.rooms[min(len(list.rooms), list.scrollOffset):min(len(list.rooms), list.scrollOffset+list.height)]
 	list.lock.Unlock()

--- a/tui/room-view.go
+++ b/tui/room-view.go
@@ -80,6 +80,9 @@ type RoomView struct {
 		time      time.Time
 	}
 
+	tempStatus       string
+	tempStatusExpiry time.Time
+
 	unlistenMeta     func()
 	unlistenTimeline func()
 }
@@ -227,8 +230,25 @@ func (view *RoomView) OnSelect(message *messages.UIMessage) {
 	view.input.Focus()
 }
 
+func (view *RoomView) SetStatusNotification(msg string, duration time.Duration) {
+	view.tempStatus = msg
+	view.tempStatusExpiry = time.Now().Add(duration)
+	if view.parent != nil && view.parent.parent != nil {
+		view.parent.parent.Render()
+	}
+}
+
 func (view *RoomView) GetStatus() string {
 	var buf strings.Builder
+
+	if view.tempStatus != "" {
+		if time.Now().Before(view.tempStatusExpiry) {
+			buf.WriteString(view.tempStatus)
+			buf.WriteString(" - ")
+		} else {
+			view.tempStatus = ""
+		}
+	}
 
 	if view.editing != nil {
 		buf.WriteString("Editing message - ")
@@ -381,6 +401,18 @@ func (view *RoomView) OnKeyEvent(event mauview.KeyEvent) bool {
 	case "scroll_down":
 		msgView.AddScrollOffset(-msgView.Height() / 2)
 		return true
+	case "reply":
+		view.StartSelecting(SelectReply, "")
+		return true
+	case "react":
+		view.StartSelecting(SelectReact, "")
+		return true
+	case "redact":
+		view.StartSelecting(SelectRedact, "")
+		return true
+	case "copy":
+		view.StartSelecting(SelectCopy, "")
+		return true
 	case "send":
 		view.InputSubmit(view.input.GetText())
 		return true
@@ -456,42 +488,16 @@ func (view *RoomView) SetEditing(evt *database.Event) {
 	//view.input.SetCursorOffset(-1)
 }
 
-type findFilter func(evt *database.Event) bool
-
 func (view *RoomView) filterOwnOnly(evt *database.Event) bool {
 	return evt.Sender == view.parent.matrix.UserID && evt.GetType() == event.EventMessage
 }
 
-//func (view *RoomView) filterMediaOnly(evt *database.Event) bool {
-//	msgtype := event.MessageType(gjson.GetBytes(evt.GetContent(), "msgtype").Str)
-//	switch msgtype {
-//	case event.MsgFile, event.MsgImage, event.MsgAudio, event.MsgVideo:
-//		return true
-//	default:
-//		return false
-//	}
-//}
-
 func (view *RoomView) findMessage(current *database.Event, forward bool, allow findFilter) *messages.UIMessage {
-	//currentFound := current == nil
-	//msgs := view.MessageView().messages
-	//for i := 0; i < len(msgs); i++ {
-	//	index := i
-	//	if !forward {
-	//		index = len(msgs) - i - 1
-	//	}
-	//	evt := msgs[index]
-	//	if evt.EventID == "" || string(evt.EventID) == evt.TxnID || evt.IsService {
-	//		continue
-	//	} else if currentFound {
-	//		if allow == nil || allow(evt.Event) {
-	//			return evt
-	//		}
-	//	} else if evt.EventID == current.ID {
-	//		currentFound = true
-	//	}
-	//}
-	return nil
+	timelinePtr := view.Room.TimelineCache.Current()
+	if timelinePtr == nil {
+		return nil
+	}
+	return findMessageInTimeline(*timelinePtr, current, forward, allow)
 }
 
 func (view *RoomView) EditNext() {
@@ -499,7 +505,9 @@ func (view *RoomView) EditNext() {
 		return
 	}
 	foundMsg := view.findMessage(view.editing, true, view.filterOwnOnly)
-	view.SetEditing(foundMsg.GetEvent())
+	if foundMsg != nil {
+		view.SetEditing(foundMsg.GetEvent())
+	}
 }
 
 func (view *RoomView) EditPrevious() {
@@ -513,32 +521,24 @@ func (view *RoomView) EditPrevious() {
 }
 
 func (view *RoomView) SelectNext() {
-	//msgView := view.MessageView()
-	//if msgView.selected == 0 {
-	//	return
-	//}
-	//var filter findFilter
-	//if view.selectReason == SelectDownload || view.selectReason == SelectOpen {
-	//	filter = view.filterMediaOnly
-	//}
-	//foundMsg := view.findMessage(msgView.selected.GetEvent(), true, filter)
-	//if foundMsg != nil {
-	//	msgView.SetSelected(foundMsg)
-	//	// TODO scroll selected message into view
-	//}
+	msgView := view.MessageView()
+	if msgView.GetSelected() == nil {
+		return
+	}
+	foundMsg := view.findMessage(msgView.GetSelected().GetEvent(), true, selectAllowed)
+	if foundMsg != nil {
+		msgView.SetSelected(foundMsg)
+		// TODO scroll selected message into view
+	}
 }
 
 func (view *RoomView) SelectPrevious() {
-	//msgView := view.MessageView()
-	//var filter findFilter
-	//if view.selectReason == SelectDownload || view.selectReason == SelectOpen {
-	//	filter = view.filterMediaOnly
-	//}
-	//foundMsg := view.findMessage(msgView.selected.GetEvent(), false, filter)
-	//if foundMsg != nil {
-	//	msgView.SetSelected(foundMsg)
-	//	// TODO scroll selected message into view
-	//}
+	msgView := view.MessageView()
+	foundMsg := view.findMessage(msgView.GetSelected().GetEvent(), false, selectAllowed)
+	if foundMsg != nil {
+		msgView.SetSelected(foundMsg)
+		// TODO scroll selected message into view
+	}
 }
 
 type completion struct {

--- a/tui/room_list_test.go
+++ b/tui/room_list_test.go
@@ -1,0 +1,89 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"go.mau.fi/util/ptr"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/gomuks/pkg/hicli/database"
+	"go.mau.fi/gomuks/pkg/hicli/jsoncmd"
+	"go.mau.fi/gomuks/pkg/rpc/client"
+	"go.mau.fi/gomuks/pkg/rpc/store"
+)
+
+func TestRoomList_SpaceFiltering(t *testing.T) {
+	st := store.NewStore()
+
+	space1 := id.RoomID("!space1:example.org")
+	space2 := id.RoomID("!space2:example.org")
+	roomA := id.RoomID("!roomA:example.org")
+	roomB := id.RoomID("!roomB:example.org")
+	roomC := id.RoomID("!roomC:example.org")
+
+	st.ApplySync(&jsoncmd.SyncComplete{
+		Rooms: map[id.RoomID]*jsoncmd.SyncRoom{
+			space1: {Meta: &database.Room{ID: space1, Name: ptr.Ptr("Space 1"), CreationContent: &event.CreateEventContent{Type: event.RoomTypeSpace}}},
+			space2: {Meta: &database.Room{ID: space2, Name: ptr.Ptr("Space 2"), CreationContent: &event.CreateEventContent{Type: event.RoomTypeSpace}}},
+			roomA:  {Meta: &database.Room{ID: roomA, Name: ptr.Ptr("Room A")}},
+			roomB:  {Meta: &database.Room{ID: roomB, Name: ptr.Ptr("Room B")}},
+			roomC:  {Meta: &database.Room{ID: roomC, Name: ptr.Ptr("Room C")}},
+		},
+		SpaceEdges: map[id.RoomID][]*database.SpaceEdge{
+			space1: {{ChildID: roomA}, {ChildID: roomB}},
+			space2: {{ChildID: roomC}},
+		},
+	})
+
+	gmx := &client.GomuksClient{
+		GomuksStore: st,
+	}
+	mainView := &MainView{
+		matrix: gmx,
+	}
+	roomList := NewRoomList(mainView)
+
+	// Initially All Rooms: contains all regular non-space rooms
+	roomList.SetActiveSpace("")
+	if len(roomList.rooms) != 3 {
+		t.Fatalf("expected 3 non-space rooms in all rooms mode, got %d", len(roomList.rooms))
+	}
+
+	// Filter by space1
+	roomList.SetActiveSpace(space1)
+	if len(roomList.rooms) != 2 {
+		t.Fatalf("expected 2 rooms in space 1, got %d", len(roomList.rooms))
+	}
+
+	// Filter by space2
+	roomList.SetActiveSpace(space2)
+	if len(roomList.rooms) != 1 {
+		t.Fatalf("expected 1 room in space 2, got %d", len(roomList.rooms))
+	}
+	if roomList.rooms[0].RoomID != roomC {
+		t.Errorf("expected roomC in space 2, got %s", roomList.rooms[0].RoomID)
+	}
+
+	// Fallback to all rooms
+	roomList.SetActiveSpace("")
+	if len(roomList.rooms) != 3 {
+		t.Fatalf("expected 3 rooms after clearing space filter, got %d", len(roomList.rooms))
+	}
+}

--- a/tui/space-switcher-modal.go
+++ b/tui/space-switcher-modal.go
@@ -17,21 +17,30 @@
 package tui
 
 import (
+	"go.mau.fi/gomuks/pkg/rpc/store"
 	"go.mau.fi/gomuks/tui/debug"
 )
 
-type FuzzySearchModal = FuzzyPickerModal
+type SpaceSwitcherModal = FuzzyPickerModal
 
-func NewFuzzySearchModal(mainView *MainView, width int, height int) *FuzzySearchModal {
-	roomList := mainView.matrix.ReversedRoomList.Current()
-	titles := make([]string, len(roomList))
-	for i, room := range roomList {
-		titles[i] = room.Name
+func NewSpaceSwitcherModal(mainView *MainView, width int, height int) *SpaceSwitcherModal {
+	rawSpaces := mainView.matrix.GetSpaceList()
+	spaceList := make([]*store.SpaceEntry, 0, len(rawSpaces)+1)
+	spaceList = append(spaceList, &store.SpaceEntry{
+		RoomID: "",
+		Name:   "All Rooms",
+	})
+	spaceList = append(spaceList, rawSpaces...)
+
+	titles := make([]string, len(spaceList))
+	for i, space := range spaceList {
+		titles[i] = space.Name
 	}
-	return NewFuzzyPickerModal(mainView, "Quick Room Switcher", titles, func(idx int) {
-		if idx >= 0 && idx < len(roomList) {
-			debug.Print("Fuzzy Selected Room:", roomList[idx].Name)
-			mainView.SwitchRoom(roomList[idx].RoomID)
+	return NewFuzzyPickerModal(mainView, "Space Switcher", titles, func(idx int) {
+		if idx >= 0 && idx < len(spaceList) {
+			selectedSpace := spaceList[idx]
+			debug.Print("Space Switcher: Selected", selectedSpace.Name, selectedSpace.RoomID)
+			mainView.SwitchToSpace(selectedSpace.RoomID)
 		}
 	}, width, height)
 }

--- a/tui/view-main.go
+++ b/tui/view-main.go
@@ -43,6 +43,7 @@ type MainView struct {
 	roomList    *RoomList
 	roomView    *mauview.Box
 	currentRoom *RoomView
+	activeSpace id.RoomID
 	//cmdProcessor *CommandProcessor
 	focused mauview.Focusable
 
@@ -177,6 +178,12 @@ func (view *MainView) OnKeyEvent(event mauview.KeyEvent) bool {
 		view.SwitchRoom(view.roomList.Previous())
 	case "search_rooms":
 		view.ShowModal(NewFuzzySearchModal(view, 42, 12))
+	case "search_spaces":
+		view.ShowModal(NewSpaceSwitcherModal(view, 42, 12))
+	case "next_space":
+		view.SwitchToNextSpace()
+	case "prev_space":
+		view.SwitchToPrevSpace()
 	case "scroll_up":
 		msgView := view.currentRoom.MessageView()
 		msgView.AddScrollOffset(msgView.TotalHeight())
@@ -272,6 +279,118 @@ func (view *MainView) SwitchRoom(roomID id.RoomID) {
 		}()
 	}
 	view.parent.Render()
+}
+
+func (view *MainView) ShowStatus(msg string) {
+	if view.currentRoom != nil {
+		view.currentRoom.SetStatusNotification(msg, 3*time.Second)
+	}
+}
+
+func (view *MainView) SwitchToSpace(spaceID id.RoomID) {
+	if spaceID == "" {
+		view.activeSpace = ""
+		view.roomList.SetActiveSpace("")
+		view.ShowStatus("Showing all rooms")
+		view.parent.Render()
+		return
+	}
+	rooms := view.matrix.GetRoomsInSpace(spaceID)
+	if len(rooms) == 0 {
+		debug.Print("Space", spaceID, "has no rooms")
+		view.ShowStatus("Space has no rooms")
+		return
+	}
+	var targetRoom id.RoomID
+	for _, roomID := range rooms {
+		if view.matrix.GetRoom(roomID) != nil {
+			targetRoom = roomID
+			break
+		}
+	}
+	if targetRoom == "" {
+		debug.Print("Space", spaceID, "has no joined rooms")
+		view.ShowStatus("Space has no joined rooms")
+		return
+	}
+
+	if view.activeSpace == spaceID && view.currentRoom != nil && view.currentRoom.Room.ID == targetRoom {
+		return
+	}
+
+	view.activeSpace = spaceID
+	view.roomList.SetActiveSpace(spaceID)
+	view.SwitchRoom(targetRoom)
+}
+
+func (view *MainView) SwitchToNextSpace() {
+	spaces := view.matrix.GetSpaceList()
+	if len(spaces) == 0 {
+		view.ShowStatus("No spaces available")
+		return
+	}
+	if len(spaces) == 1 {
+		if view.activeSpace == spaces[0].RoomID {
+			return
+		}
+		view.SwitchToSpace(spaces[0].RoomID)
+		return
+	}
+	if view.activeSpace != "" {
+		for i, space := range spaces {
+			if space.RoomID == view.activeSpace {
+				nextSpace := spaces[(i+1)%len(spaces)]
+				view.SwitchToSpace(nextSpace.RoomID)
+				return
+			}
+		}
+	}
+	currentRoom := view.currentRoom
+	if currentRoom != nil {
+		for i, space := range spaces {
+			if view.matrix.IsRoomInSpace(space.RoomID, currentRoom.Room.ID) {
+				nextSpace := spaces[(i+1)%len(spaces)]
+				view.SwitchToSpace(nextSpace.RoomID)
+				return
+			}
+		}
+	}
+	view.SwitchToSpace(spaces[0].RoomID)
+}
+
+func (view *MainView) SwitchToPrevSpace() {
+	spaces := view.matrix.GetSpaceList()
+	if len(spaces) == 0 {
+		view.ShowStatus("No spaces available")
+		return
+	}
+	if len(spaces) == 1 {
+		if view.activeSpace == spaces[0].RoomID {
+			return
+		}
+		view.SwitchToSpace(spaces[0].RoomID)
+		return
+	}
+	if view.activeSpace != "" {
+		for i, space := range spaces {
+			if space.RoomID == view.activeSpace {
+				prevSpace := spaces[(i-1+len(spaces))%len(spaces)]
+				view.SwitchToSpace(prevSpace.RoomID)
+				return
+			}
+		}
+	}
+	currentRoom := view.currentRoom
+	if currentRoom != nil {
+		for i, space := range spaces {
+			if view.matrix.IsRoomInSpace(space.RoomID, currentRoom.Room.ID) {
+				prevSpace := spaces[(i-1+len(spaces))%len(spaces)]
+				view.SwitchToSpace(prevSpace.RoomID)
+				return
+			}
+		}
+	}
+	view.SwitchToSpace(spaces[len(spaces)-1].RoomID)
 }
 
 func (view *MainView) NotifyMessage(room *store.RoomStore, notif jsoncmd.SyncNotification) {


### PR DESCRIPTION
### Description
This pull request adds **Matrix Space (Workspace) navigation** and interactive fuzzy search improvements to the TUI client (`gomuks-terminal`):

1. **Space Switcher Modal (`Ctrl+s` / `Alt+s`)**:
   - Interactive modal to fuzzy-search across all joined Matrix Spaces.
   - Automatically pre-populates all spaces upon opening with `"All Rooms"` at the top.
   - Selecting a Space filters the visible sidebar room list to child rooms of that space.
   - Selecting `"All Rooms"` resets the filter to show all non-space rooms.

2. **Space Cycling Hotkeys (`Ctrl+]` / `Ctrl+[` or `Alt+]` / `Alt+[` )**:
   - `SwitchToNextSpace()` and `SwitchToPrevSpace()`: directly cycle through joined spaces.
   - Guards against single-space no-op loops and notifies users when spaces contain no joined rooms.

3. **Shared Fuzzy Picker Modal (`FuzzyPickerModal`)**:
   - Extracted a generic, reusable fuzzy picker widget (`tui/fuzzy-picker-modal.go`).
   - Refactored `FuzzySearchModal` (`Ctrl+k` room search) and `SpaceSwitcherModal` (`Ctrl+s`) to share the same component, eliminating duplicate fuzzy search/modal logic.

4. **Space Graph Indexing (`pkg/rpc/store/store.go`)**:
   - Tracks `m.space.child` hierarchy edges in `GomuksStore`.
   - Thread-safe helpers: `GetSpaceList()`, `GetRoomsInSpace()`, `IsRoomInSpace()`.

### Tests
- `pkg/rpc/store/space_test.go`: Unit tests for space graph indexing, deletion, and sorting.
- `tui/fuzzy_picker_test.go`: Tests for initial pre-population, fuzzy ranking, circular navigation, and query erasure restoration.
- `tui/room_list_test.go`: Tests for room list filtering by active space and fallback to all rooms.
- `tui/config/keybindings_test.go`: Tests for keybinding parsing and modal actions.